### PR TITLE
fix: prevent warning when called with undefined or null during develo…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import './styles.css';
 import { FieldTagging } from './field-tagging';
 import { LiveUpdates } from './live-updates';
-import { Entity, LivePreviewProps, SubscribeCallback, TagAttributes } from './types';
+import { Argument, LivePreviewProps, SubscribeCallback, TagAttributes } from './types';
 import { sendMessageToEditor } from './utils';
 
 export class ContentfulLivePreview {
@@ -37,7 +37,7 @@ export class ContentfulLivePreview {
     }
   }
 
-  static subscribe(data: Entity, locale: string, callback: SubscribeCallback): VoidFunction {
+  static subscribe(data: Argument, locale: string, callback: SubscribeCallback): VoidFunction {
     if (!this.liveUpdates) {
       throw new Error(
         'Live Updates are not initialized, please call `ContentfulLivePreview.init()` first.'

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,22 +1,22 @@
 import { useState } from 'react';
 
-import useDeepCompareEffect from 'use-deep-compare-effect';
+import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect';
 
 import { ContentfulLivePreview } from '.';
-import { Entity } from './types';
+import { Argument } from './types';
 import { debounce } from './utils';
 
-export function useContentfulLiveUpdates<T extends Entity | null | undefined>(
+export function useContentfulLiveUpdates<T extends Argument | null | undefined>(
   data: T,
   locale: string
 ): T {
   const [state, setState] = useState(data);
 
-  useDeepCompareEffect(() => {
+  useDeepCompareEffectNoCheck(() => {
     // update content from external
     setState(data);
-    // nothing to merge if there are no data
-    if (!data) {
+    // nothing to merge if there is no data
+    if (!data || (Array.isArray(data) && !data.length) || !Object.keys(data).length) {
       return;
     }
     // or update content through live updates

--- a/src/tests/react.spec.ts
+++ b/src/tests/react.spec.ts
@@ -4,6 +4,7 @@ import { act, renderHook } from '@testing-library/react';
 
 import { useContentfulLiveUpdates } from '../react';
 import { ContentfulLivePreview } from '..';
+import { Argument } from '../types';
 
 describe('useContentfulLiveUpdates', () => {
   const unsubscribe = vi.fn();
@@ -99,5 +100,17 @@ describe('useContentfulLiveUpdates', () => {
 
     expect(result.current).toEqual(updatedData);
     expect(counter).toEqual(2);
+  });
+
+  it('shouldnt listen to changes if the initial data is empty', () => {
+    const { rerender } = renderHook((data) => useContentfulLiveUpdates(data, locale), {
+      initialProps: undefined as Argument | null | undefined,
+    });
+
+    rerender(null);
+    rerender([]);
+    rerender({});
+
+    expect(subscribe).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
fix: prevent warning when called with undefined or null during development.

useDeepCompareEffect has an integrated check if the provided dependencies are primitives during development.
As the provided data can be `null` or `undefined` during loading, it will throw an error which can crash the Developer Experience.
