### PR TITLE
chore(live-updates): handle merge errors []

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ContentfulLivePreview.init();
 
 ### Field Tagging
 
-To tag fields you need to add the live preview data-attributes to the rendered HTML element output.
+To tag fields you need to add the live preview data-attributes (`data-contentful-entry-id`, `data-contentful-field-id`, `data-contentful-locale`) to the rendered HTML element output.
 You can do this in React via our helper function.
 The necessary styles for the live edit tags can be found in the '@contentful/live-preview/style.css' file.
 

--- a/src/liveUpdates.ts
+++ b/src/liveUpdates.ts
@@ -178,20 +178,28 @@ export class LiveUpdates {
   }: Record<string, unknown>): void {
     if (this.isCfEntity(entity)) {
       this.subscriptions.forEach((s) => {
-        const { updated, data } = this.merge({
-          // Clone the original data on the top level,
-          // to prevent cloning multiple times (time)
-          // or modifying the original data (failure potential)
-          dataFromPreviewApp: clone(s.data),
-          locale: s.locale,
-          updateFromEntryEditor: entity,
-          contentType: contentType as ContentType,
-          entityReferenceMap: entityReferenceMap as EntityReferenceMap,
-        });
+        try {
+          const { updated, data } = this.merge({
+            // Clone the original data on the top level,
+            // to prevent cloning multiple times (time)
+            // or modifying the original data (failure potential)
+            dataFromPreviewApp: clone(s.data),
+            locale: s.locale,
+            updateFromEntryEditor: entity,
+            contentType: contentType as ContentType,
+            entityReferenceMap: entityReferenceMap as EntityReferenceMap,
+          });
 
-        // Only if there was an update, trigger the callback to unnecessary re-renders
-        if (updated) {
-          s.cb(data);
+          // Only if there was an update, trigger the callback to unnecessary re-renders
+          if (updated) {
+            s.cb(data);
+          }
+        } catch (error) {
+          debug.error('Failed to apply live update', {
+            error,
+            subscribedData: s.data,
+            updateFromEditor: entity,
+          });
         }
       });
     }


### PR DESCRIPTION
Currently if a error occurs, it goes wild - let's handle it to write the information in the debug.error function and not crashes the client application