### PR TITLE
fix(live-updates): add support for videos, currently they are not processed correctly [TOL-1173]

### DIFF
--- a/src/graphql/assets.ts
+++ b/src/graphql/assets.ts
@@ -26,9 +26,10 @@ export function updateAsset<T extends (Entity & { sys: SysProps }) | EntryProps>
       title: updateFromEntryEditor.fields.title[locale],
       description: updateFromEntryEditor.fields.description?.[locale],
       contentType: file.contentType,
-      width: file.details?.image.width,
-      height: file.details?.image.height,
       url: setProtocolToHttps(file.url),
+      // Note: video has no `width` and `height`
+      width: file.details?.image?.width,
+      height: file.details?.image?.height,
     };
   } catch (err) {
     // During file upload it will throw an error and return the original data in the meantime


### PR DESCRIPTION
Videos doesn't have the width and height information, so therefor they are currently not updating correctly.
This can lead to issues on the app side as the returned information are not the same as expected.