### PR TITLE
fix: conditionally check correct props [NONE]

### DIFF
--- a/src/react.tsx
+++ b/src/react.tsx
@@ -112,7 +112,7 @@ type GetInspectorModeProps<T> = (props: {
  * Generates the function to build the required properties for the inspector mode (field tagging)
  */
 export function useContentfulInspectorMode<
-  T = undefined | Pick<LivePreviewProps, 'entryId'> | Pick<LivePreviewProps, 'entryId' | 'locale'>
+  T = undefined | Pick<LivePreviewProps, 'entryId'> | Pick<LivePreviewProps, 'entryId' | 'fieldId'>
 >(sharedProps?: T): GetInspectorModeProps<T> {
   const config = useContext(ContentfulLivePreviewContext);
 


### PR DESCRIPTION
We had a bug with the inspector props & the locale was treated as a required prop for inspector mode even after the locale optimisation was added. this should fix that