### PR TITLE
fix(references): move to promises to optimize loading behaviour

### DIFF
--- a/src/__tests__/inspectorMode.spec.ts
+++ b/src/__tests__/inspectorMode.spec.ts
@@ -17,15 +17,20 @@ describe('InspectorMode', () => {
   });
 
   describe('receiveMessage', () => {
-    test("shouldn't change anything if the incoming message doesnt contain 'isInspectorActive'", () => {
+    test("shouldn't change anything if the incoming message isnt the correct action", () => {
       const spy = vi.spyOn(document.body.classList, 'toggle');
-      inspectorMode.receiveMessage({ entitiy: {} });
+      // @ts-expect-error -- only for test
+      inspectorMode.receiveMessage({ action: 'ENTRY_UPDATED' });
       expect(spy).not.toHaveBeenCalled();
     });
 
     test('should toggle "contentful-inspector--active" class on document.body based on value of isInspectorActive', () => {
       const spy = vi.spyOn(document.body.classList, 'toggle');
-      inspectorMode.receiveMessage({ from: 'live-preview', isInspectorActive: true });
+      inspectorMode.receiveMessage({
+        from: 'live-preview',
+        isInspectorActive: true,
+        action: 'INSPECTOR_MODE_CHANGED',
+      });
       expect(spy).toHaveBeenCalledWith('contentful-inspector--active', true);
     });
   });

--- a/src/__tests__/liveUpdates.spec.ts
+++ b/src/__tests__/liveUpdates.spec.ts
@@ -99,19 +99,6 @@ describe('LiveUpdates', () => {
         data
       );
     });
-
-    it('should notify because we dont know if it is REST or GraphQL', () => {
-      const liveUpdates = new LiveUpdates({ locale });
-      const data = { sys: { id: '1' }, title: 'Data 1' };
-      const callback = vi.fn();
-
-      liveUpdates.subscribe({ data, callback });
-
-      expect(helpers.debug.error).toHaveBeenCalledWith(
-        'For live updates as a basic requirement the provided data must include the "fields" property for REST or "__typename" for Graphql, otherwise the data will be treated as invalid and live updates will not work.',
-        data
-      );
-    });
   });
 
   it('no longer receives updates after unsubcribing', async () => {

--- a/src/__tests__/resolveReference.spec.ts
+++ b/src/__tests__/resolveReference.spec.ts
@@ -57,7 +57,7 @@ describe('resolveReference', () => {
     });
 
     it('resolves it from the editor', async () => {
-      const prom = resolveReference({
+      const promise = resolveReference({
         entityReferenceMap: new Map(),
         referenceId: '1',
         isAsset: true,
@@ -79,13 +79,13 @@ describe('resolveReference', () => {
         },
       } as MessageEvent);
 
-      const result = await prom;
+      const result = await promise;
 
       expect(result).toEqual(expected);
     });
 
     it('ignores different entries while waiting for the reference', async () => {
-      const prom = resolveReference({
+      const promise = resolveReference({
         entityReferenceMap: new Map(),
         referenceId: '1',
         isAsset: true,
@@ -123,19 +123,19 @@ describe('resolveReference', () => {
         },
       } as MessageEvent);
 
-      const result = await prom;
+      const result = await promise;
 
       expect(result).toEqual(expected);
     });
 
     it('dedupes requests', async () => {
-      const prom = resolveReference({
+      const promise = resolveReference({
         entityReferenceMap: new Map(),
         referenceId: '1',
         isAsset: true,
       });
 
-      const prom2 = resolveReference({
+      const promise2 = resolveReference({
         entityReferenceMap: new Map(),
         referenceId: '1',
         isAsset: true,
@@ -149,8 +149,8 @@ describe('resolveReference', () => {
         },
       } as MessageEvent);
 
-      const result = await prom;
-      const result2 = await prom2;
+      const result = await promise;
+      const result2 = await promise2;
 
       expect(result).toEqual(expected);
       expect(result2).toEqual(expected);
@@ -198,7 +198,7 @@ describe('resolveReference', () => {
     });
 
     it('resolves it from the editor', async () => {
-      const prom = resolveReference({
+      const promise = resolveReference({
         entityReferenceMap: new Map(),
         referenceId: '1',
       });
@@ -219,7 +219,7 @@ describe('resolveReference', () => {
         },
       } as MessageEvent);
 
-      const result = await prom;
+      const result = await promise;
 
       expect(result).toEqual(expected);
     });

--- a/src/__tests__/resolveReference.spec.ts
+++ b/src/__tests__/resolveReference.spec.ts
@@ -1,0 +1,227 @@
+/* @vitest-environment jsdom */
+import type { AssetProps, EntryProps } from 'contentful-management';
+import { beforeEach, describe, vi, it, afterEach, expect } from 'vitest';
+
+import { sendMessageToEditor } from '../helpers';
+import { resolveReference } from '../helpers/resolveReference';
+import { ASSET_TYPENAME } from '../types';
+
+vi.mock('../helpers/utils');
+
+describe('resolveReference', () => {
+  const listener = vi.spyOn(window, 'addEventListener');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe('asset', () => {
+    const asset = {
+      fields: {
+        file: { 'en-US': { fileName: 'abc.jpg' } },
+      },
+      sys: {
+        id: '1',
+      },
+    } as unknown as AssetProps;
+
+    const expected = {
+      reference: {
+        fields: {
+          file: {
+            'en-US': {
+              fileName: 'abc.jpg',
+            },
+          },
+        },
+        sys: {
+          id: '1',
+        },
+      },
+      typeName: 'Asset',
+    };
+
+    it('resolves it directly from the map', async () => {
+      const result = await resolveReference({
+        entityReferenceMap: new Map([['1', asset]]),
+        referenceId: '1',
+      });
+
+      expect(result).toEqual(expected);
+    });
+
+    it('resolves it from the editor', async () => {
+      const prom = resolveReference({
+        entityReferenceMap: new Map(),
+        referenceId: '1',
+        isAsset: true,
+      });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(sendMessageToEditor).toHaveBeenCalledTimes(1);
+      expect(sendMessageToEditor).toHaveBeenCalledWith({
+        action: 'ENTITY_NOT_KNOWN',
+        referenceEntityId: '1',
+        referenceContentType: ASSET_TYPENAME,
+      });
+
+      (listener.mock.calls[0][1] as EventListener)({
+        data: {
+          from: 'live-preview',
+          action: 'UNKNOWN_REFERENCE_LOADED',
+          reference: asset,
+        },
+      } as MessageEvent);
+
+      const result = await prom;
+
+      expect(result).toEqual(expected);
+    });
+
+    it('ignores different entries while waiting for the reference', async () => {
+      const prom = resolveReference({
+        entityReferenceMap: new Map(),
+        referenceId: '1',
+        isAsset: true,
+      });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(sendMessageToEditor).toHaveBeenCalledTimes(1);
+      expect(sendMessageToEditor).toHaveBeenCalledWith({
+        action: 'ENTITY_NOT_KNOWN',
+        referenceEntityId: '1',
+        referenceContentType: ASSET_TYPENAME,
+      });
+
+      (listener.mock.calls[0][1] as EventListener)({
+        data: {
+          from: 'live-preview',
+          action: 'UNKNOWN_REFERENCE_LOADED',
+          reference: { sys: { id: '2' } },
+        },
+      } as MessageEvent);
+
+      (listener.mock.calls[0][1] as EventListener)({
+        data: {
+          from: 'live-preview',
+          action: 'INSPECTOR_MODE_CHANGED',
+          isInspectorActive: false,
+        },
+      } as MessageEvent);
+
+      (listener.mock.calls[0][1] as EventListener)({
+        data: {
+          from: 'live-preview',
+          action: 'UNKNOWN_REFERENCE_LOADED',
+          reference: asset,
+        },
+      } as MessageEvent);
+
+      const result = await prom;
+
+      expect(result).toEqual(expected);
+    });
+
+    it('dedupes requests', async () => {
+      const prom = resolveReference({
+        entityReferenceMap: new Map(),
+        referenceId: '1',
+        isAsset: true,
+      });
+
+      const prom2 = resolveReference({
+        entityReferenceMap: new Map(),
+        referenceId: '1',
+        isAsset: true,
+      });
+
+      (listener.mock.calls[0][1] as EventListener)({
+        data: {
+          from: 'live-preview',
+          action: 'UNKNOWN_REFERENCE_LOADED',
+          reference: asset,
+        },
+      } as MessageEvent);
+
+      const result = await prom;
+      const result2 = await prom2;
+
+      expect(result).toEqual(expected);
+      expect(result2).toEqual(expected);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('entries', () => {
+    const entry = {
+      fields: {
+        title: { 'en-US': 'Hello World' },
+      },
+      sys: {
+        id: '1',
+        contentType: {
+          sys: { id: 'helloWorld' },
+        },
+      },
+    } as unknown as EntryProps;
+
+    const expected = {
+      reference: {
+        fields: {
+          title: {
+            'en-US': 'Hello World',
+          },
+        },
+        sys: {
+          id: '1',
+          contentType: {
+            sys: { id: 'helloWorld' },
+          },
+        },
+      },
+      typeName: 'HelloWorld',
+    };
+
+    it('resolves it directly from the map', async () => {
+      const result = await resolveReference({
+        entityReferenceMap: new Map([['1', entry]]),
+        referenceId: '1',
+      });
+
+      expect(result).toEqual(expected);
+    });
+
+    it('resolves it from the editor', async () => {
+      const prom = resolveReference({
+        entityReferenceMap: new Map(),
+        referenceId: '1',
+      });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(sendMessageToEditor).toHaveBeenCalledTimes(1);
+      expect(sendMessageToEditor).toHaveBeenCalledWith({
+        action: 'ENTITY_NOT_KNOWN',
+        referenceEntityId: '1',
+      });
+
+      (listener.mock.calls[0][1] as EventListener)({
+        data: {
+          from: 'live-preview',
+          action: 'UNKNOWN_REFERENCE_LOADED',
+          reference: entry,
+          contentType: entry.sys.contentType,
+        },
+      } as MessageEvent);
+
+      const result = await prom;
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/src/__tests__/validation.spec.ts
+++ b/src/__tests__/validation.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { debug } from '../helpers';
+import { validateDataForLiveUpdates } from '../helpers/validation';
+
+vi.mock('../helpers/debug');
+
+describe('validateDataForLiveUpdates', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('REST', () => {
+    it('detects REST structure on the top level', () => {
+      const result = validateDataForLiveUpdates({
+        sys: { id: '123' },
+        fields: {
+          title: { 'en-US': 'Hello World' },
+        },
+      });
+
+      expect(debug.error).not.toHaveBeenCalled();
+
+      expect(result).toEqual({
+        isGQL: false,
+        isREST: true,
+        hasSys: true,
+        isValid: true,
+      });
+    });
+
+    it('detects REST structure inside lists', () => {
+      const result = validateDataForLiveUpdates([
+        {
+          sys: { id: '123' },
+          fields: {
+            title: { 'en-US': 'Hello World' },
+          },
+        },
+      ]);
+
+      expect(debug.error).not.toHaveBeenCalled();
+
+      expect(result).toEqual({
+        isGQL: false,
+        isREST: true,
+        hasSys: true,
+        isValid: true,
+      });
+    });
+
+    it('detects REST structure in a nested structure', () => {
+      const result = validateDataForLiveUpdates({
+        items: [
+          {
+            sys: { id: '123' },
+            fields: {
+              title: { 'en-US': 'Hello World' },
+            },
+          },
+        ],
+      });
+
+      expect(debug.error).not.toHaveBeenCalled();
+
+      expect(result).toEqual({
+        isGQL: false,
+        isREST: true,
+        hasSys: true,
+        isValid: true,
+      });
+    });
+  });
+
+  describe('GraphQL', () => {
+    it('detects GraphQL structure on the top level', () => {
+      const result = validateDataForLiveUpdates({
+        sys: { id: '123' },
+        title: { 'en-US': 'Hello World' },
+        __typename: 'hello',
+      });
+
+      expect(debug.error).not.toHaveBeenCalled();
+
+      expect(result).toEqual({
+        isGQL: true,
+        isREST: false,
+        hasSys: true,
+        isValid: true,
+      });
+    });
+
+    it('detects REST structure inside lists', () => {
+      const result = validateDataForLiveUpdates([
+        {
+          sys: { id: '123' },
+          title: { 'en-US': 'Hello World' },
+          __typename: 'hello',
+        },
+      ]);
+
+      expect(debug.error).not.toHaveBeenCalled();
+
+      expect(result).toEqual({
+        isGQL: true,
+        isREST: false,
+        hasSys: true,
+        isValid: true,
+      });
+    });
+
+    it('detects REST structure in a nested structure', () => {
+      const result = validateDataForLiveUpdates({
+        collection: {
+          items: [
+            {
+              sys: { id: '123' },
+              title: { 'en-US': 'Hello World' },
+              __typename: 'hello',
+            },
+          ],
+        },
+      });
+
+      expect(debug.error).not.toHaveBeenCalled();
+
+      expect(result).toEqual({
+        isGQL: true,
+        isREST: false,
+        hasSys: true,
+        isValid: true,
+      });
+    });
+  });
+
+  describe('invalid', () => {
+    it('warns about missing sys information', () => {
+      const data = {
+        title: { 'en-US': 'Hello World' },
+        __typename: 'hello',
+      };
+      const result = validateDataForLiveUpdates(data);
+
+      expect(debug.error).toHaveBeenCalledTimes(1);
+      expect(debug.error).toHaveBeenCalledWith(
+        'Live Updates requires the "sys.id" to be present on the provided data',
+        data
+      );
+
+      expect(result).toEqual({
+        isGQL: true,
+        isREST: false,
+        hasSys: false,
+        isValid: false,
+      });
+    });
+
+    it('warns that it is neither REST or GraphQL', () => {
+      const data = {
+        sys: { id: '1' },
+      };
+      const result = validateDataForLiveUpdates(data);
+
+      expect(debug.error).toHaveBeenCalledTimes(1);
+      expect(debug.error).toHaveBeenCalledWith(
+        'For live updates as a basic requirement the provided data must include the "fields" property for REST or "__typename" for Graphql, otherwise the data will be treated as invalid and live updates are not applied.',
+        data
+      );
+
+      expect(result).toEqual({
+        isGQL: false,
+        isREST: false,
+        hasSys: true,
+        isValid: false,
+      });
+    });
+  });
+});

--- a/src/graphql/entries.ts
+++ b/src/graphql/entries.ts
@@ -10,6 +10,7 @@ import {
   UpdateFieldProps,
   UpdateReferenceFieldProps,
   UpdateEntryProps,
+  isAsset,
 } from '../types';
 import { updateAsset } from './assets';
 import { buildCollectionName, logUnrecognizedFields } from './utils';
@@ -89,10 +90,6 @@ function updateRichTextField({
     (dataFromPreviewApp[name] as { json: unknown }).json =
       updateFromEntryEditor?.fields?.[name]?.[locale] ?? null;
   }
-}
-
-function isAsset(entity: EntryProps | (Entity & CollectionItem)): boolean {
-  return 'linkType' in entity.sys && entity.sys.linkType === ASSET_TYPENAME;
 }
 
 async function updateReferenceAssetField({

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -3,3 +3,4 @@ export * from './field';
 export * from './utils';
 export * from './uuid';
 export * from './pollUrlChanges';
+export * from './resolveReference';

--- a/src/helpers/resolveReference.ts
+++ b/src/helpers/resolveReference.ts
@@ -1,0 +1,106 @@
+import type { AssetProps, EntryProps } from 'contentful-management';
+
+import { ASSET_TYPENAME, EntityReferenceMap, MessageFromEditor } from '../types';
+import { sendMessageToEditor } from './utils';
+
+type ReferencePromise = Promise<{
+  reference: EntryProps | AssetProps;
+  typeName: string;
+}>;
+
+const PromiseMap = new Map<string, ReferencePromise>();
+
+function generateTypeName(contentTypeId: string): string {
+  return contentTypeId.charAt(0).toUpperCase() + contentTypeId.slice(1);
+}
+
+function promiseCleanup(referenceId: string) {
+  setTimeout(() => {
+    PromiseMap.delete(referenceId);
+  }, 300);
+}
+
+function loadReference(referenceId: string, isAsset?: boolean): ReferencePromise {
+  const openPromise = PromiseMap.get(referenceId);
+
+  if (openPromise) {
+    return openPromise;
+  }
+
+  const newPromise = new Promise<Awaited<ReferencePromise>>((resolve) => {
+    const fn = (event: MessageEvent<MessageFromEditor>) => {
+      if (typeof event.data !== 'object' || !event.data) return;
+      if (event.data.from !== 'live-preview') return;
+
+      // Check if the correct event is received and it contains the correct data (there could be multiple unknown references)
+      if (
+        event.data.action === 'UNKNOWN_REFERENCE_LOADED' &&
+        event.data.reference.sys.id === referenceId
+      ) {
+        resolve({
+          reference: event.data.reference,
+          typeName: event.data.contentType
+            ? generateTypeName(event.data.contentType.sys.id)
+            : ASSET_TYPENAME,
+        });
+        promiseCleanup(referenceId);
+        window.removeEventListener('message', fn);
+      }
+    };
+
+    window.addEventListener('message', fn);
+
+    sendMessageToEditor({
+      action: 'ENTITY_NOT_KNOWN',
+      referenceEntityId: referenceId,
+      referenceContentType: isAsset ? ASSET_TYPENAME : undefined,
+    });
+  });
+
+  PromiseMap.set(referenceId, newPromise);
+
+  return newPromise;
+}
+
+export async function resolveReference(info: {
+  entityReferenceMap: EntityReferenceMap;
+  referenceId: string;
+  isAsset?: false;
+}): Promise<{ reference: EntryProps; typeName: string }>;
+export async function resolveReference(info: {
+  entityReferenceMap: EntityReferenceMap;
+  referenceId: string;
+  isAsset: true;
+}): Promise<{ reference: AssetProps; typeName: string }>;
+/**
+ * Returns the requested reference from
+ * 1) the entityReferenceMap if it was already resolved once
+ * 2) loads it from the editor directly
+ */
+export async function resolveReference({
+  entityReferenceMap,
+  referenceId,
+  isAsset,
+}: {
+  entityReferenceMap: EntityReferenceMap;
+  referenceId: string;
+  isAsset?: boolean;
+}): Promise<{ reference: EntryProps | AssetProps; typeName: string }> {
+  const reference = entityReferenceMap.get(referenceId);
+
+  if (!reference) {
+    const result = await loadReference(referenceId, isAsset);
+
+    return {
+      reference: result.reference,
+      typeName: result.typeName,
+    };
+  }
+
+  return {
+    reference,
+    typeName: reference.sys.contentType?.sys?.id
+      ? generateTypeName(reference.sys.contentType.sys.id)
+      : ASSET_TYPENAME,
+  };
+}

--- a/src/helpers/resolveReference.ts
+++ b/src/helpers/resolveReference.ts
@@ -65,7 +65,6 @@ function loadReference(referenceId: string, isAsset?: boolean): ReferencePromise
 export async function resolveReference(info: {
   entityReferenceMap: EntityReferenceMap;
   referenceId: string;
-  isAsset?: false;
 }): Promise<{ reference: EntryProps; typeName: string }>;
 export async function resolveReference(info: {
   entityReferenceMap: EntityReferenceMap;

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -10,6 +10,7 @@ export function sendMessageToEditor(data: EditorMessage): void {
     ...data,
     from: 'live-preview',
     location: window.location.href,
+    version: '2.2.0', // TODO: set this automatically during publish (TOL-1178)
   };
 
   window.top?.postMessage(

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -1,0 +1,62 @@
+import { Argument } from '../types';
+import { debug } from './debug';
+
+function validation(d: Argument): { isGQL: boolean; hasSys: boolean; isREST: boolean } {
+  if (Array.isArray(d)) {
+    for (const value of d) {
+      const result = validation(value);
+
+      if (Object.values(result).includes(true)) {
+        return result;
+      }
+    }
+
+    return { isGQL: false, hasSys: false, isREST: false };
+  } else {
+    const isGQL = Object.hasOwn(d, '__typename');
+    const hasSys = Object.hasOwn(d, 'sys');
+    const isREST = Object.hasOwn(d, 'fields');
+
+    if (isGQL || hasSys || isREST) {
+      return { isGQL, hasSys, isREST };
+    }
+
+    // maybe it's nested
+    return validation(Object.values(d) as Argument);
+  }
+}
+
+/**
+ * **Basic** validating of the subscribed data
+ * Is it GraphQL or REST and does it contain the sys information
+ */
+export function validateDataForLiveUpdates(data: Argument): {
+  isGQL: boolean;
+  isREST: boolean;
+  hasSys: boolean;
+  isValid: boolean;
+} {
+  let isValid = true;
+
+  const { isGQL, hasSys, isREST } = validation(data);
+
+  if (!hasSys) {
+    isValid = false;
+    debug.error('Live Updates requires the "sys.id" to be present on the provided data', data);
+  }
+
+  if (!isGQL && !isREST) {
+    isValid = false;
+    debug.error(
+      'For live updates as a basic requirement the provided data must include the "fields" property for REST or "__typename" for Graphql, otherwise the data will be treated as invalid and live updates are not applied.',
+      data
+    );
+  }
+
+  return {
+    isGQL,
+    isREST,
+    hasSys,
+    isValid,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   Argument,
   InspectorModeTags,
   LivePreviewProps,
+  MessageFromEditor,
   SubscribeCallback,
   Subscription,
   TagAttributes,
@@ -89,7 +90,7 @@ export class ContentfulLivePreview {
       }
 
       // bind event listeners for interactivity
-      window.addEventListener('message', (event) => {
+      window.addEventListener('message', (event: MessageEvent<MessageFromEditor>) => {
         if (typeof event.data !== 'object' || !event.data) return;
         if (event.data.from !== 'live-preview') return;
 

--- a/src/inspectorMode.ts
+++ b/src/inspectorMode.ts
@@ -7,7 +7,7 @@ import {
   TOOLTIP_PADDING_LEFT,
 } from './constants';
 import { sendMessageToEditor } from './helpers';
-import { TagAttributes } from './types';
+import { MessageFromEditor, TagAttributes } from './types';
 
 export class InspectorMode {
   private tooltip: HTMLButtonElement | null = null; // this tooltip scrolls to the correct field in the entry editor
@@ -30,8 +30,8 @@ export class InspectorMode {
   }
 
   // Handles incoming messages from Contentful
-  public receiveMessage(data: Record<string, unknown>): void {
-    if (typeof data.isInspectorActive === 'boolean') {
+  public receiveMessage(data: MessageFromEditor): void {
+    if (data.action === 'INSPECTOR_MODE_CHANGED') {
       // Toggle the contentful-inspector--active class on the body element based on the isInspectorActive boolean
       document.body.classList.toggle('contentful-inspector--active', data.isInspectorActive);
     }

--- a/src/liveUpdates.ts
+++ b/src/liveUpdates.ts
@@ -80,7 +80,7 @@ export class LiveUpdates {
     if (this.isCfEntity(dataFromPreviewApp)) {
       // REST
       return {
-        data: rest.updateEntity(
+        data: await rest.updateEntity(
           contentType,
           dataFromPreviewApp as EntryProps,
           updateFromEntryEditor as EntryProps,

--- a/src/rest/entities.ts
+++ b/src/rest/entities.ts
@@ -30,8 +30,7 @@ async function updateRef(
   const { reference } = await resolveReference({
     entityReferenceMap,
     referenceId: updateFromEntryEditor.sys.id,
-    // @ts-expect-error -- true or false is not equal to boolean
-    isAsset: isAsset(updateFromEntryEditor as EntryProps),
+    ...(isAsset(updateFromEntryEditor as EntryProps) ? { isAsset: true } : undefined),
   });
 
   if (!reference) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,3 +144,7 @@ export interface Subscription {
   locale?: string;
   callback: SubscribeCallback;
 }
+
+export function isAsset(entity: EntryProps | (Entity & CollectionItem)): boolean {
+  return 'linkType' in entity.sys && entity.sys.linkType === ASSET_TYPENAME;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,8 @@ type SubscribedMessage = {
   type: 'GQL' | 'REST';
 };
 
+export class EntityReferenceMap extends Map<string, EntryProps | AssetProps> {}
+
 export type EditorMessage =
   | IframeConnectedMessage
   | TaggedFieldClickMessage
@@ -87,9 +89,32 @@ export type EditorMessage =
 export type MessageFromSDK = EditorMessage & {
   from: 'live-preview';
   location: string;
+  version: string;
 };
 
-export class EntityReferenceMap extends Map<string, EntryProps | AssetProps> {}
+export type EntryUpdatedMessage = {
+  action: 'ENTRY_UPDATED';
+  entity: EntryProps | AssetProps;
+  contentType: ContentType;
+  entityReferenceMap: EntityReferenceMap;
+};
+
+type UnknownReferenceLoaded = {
+  action: 'UNKNOWN_REFERENCE_LOADED';
+  reference: EntryProps | AssetProps;
+  contentType?: ContentType;
+  entityReferenceMap: EntityReferenceMap;
+};
+
+type InspectorModeChanged = { action: 'INSPECTOR_MODE_CHANGED'; isInspectorActive: boolean };
+
+export type MessageFromEditor = (
+  | EntryUpdatedMessage
+  | UnknownReferenceLoaded
+  | InspectorModeChanged
+) & {
+  from: 'live-preview';
+};
 
 export type UpdateEntryProps = {
   contentType: ContentType;
@@ -105,7 +130,6 @@ export type UpdateFieldProps = {
   name: string;
   locale: string;
   entityReferenceMap?: EntityReferenceMap;
-  depth?: number;
 };
 
 export type UpdateReferenceFieldProps = {
@@ -113,7 +137,6 @@ export type UpdateReferenceFieldProps = {
   updatedReference: Entity & CollectionItem;
   entityReferenceMap: EntityReferenceMap;
   locale: string;
-  depth?: number;
 };
 
 export interface Subscription {


### PR DESCRIPTION
1. We have the case that not everything is resolved correctly on nested references
2. We would need to return only partial data to resolve then in the next step the reference correctly

This two cases can lead to a broken UI if the handling of data is not checking things very precise on their part.
Let's make the entity not known a promise and build everything async.

- [ ] Update message sender to include the action before merging this one