### PR TITLE
docs(draft-mode): update workaround to share the draft mode with an iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ We suggest using the [draft mode](https://nextjs.org/docs/pages/building-your-ap
 
 For a full guide checkout this [free course](https://www.contentful.com/nextjs-starter-guide/)
 
+> Due some security settings the draft mode is not always shared with the iframe.<br>You can find a workaround in our [examples](./examples/nextjs-graphql/pages/api/draft.ts#L25)
+
 5. In Contentful, configure the draft URL for your Next.js application in the Content preview settings. Once you open an entry with a configured preview URL, you can use the live preview and all its features.
 
 That's it! You should now be able to use the Contentful live preview SDK with Next.js.

--- a/examples/nextjs-graphql/pages/api/disable-draft.ts
+++ b/examples/nextjs-graphql/pages/api/disable-draft.ts
@@ -1,5 +1,22 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { COOKIE_NAME_PRERENDER_BYPASS } from 'next/dist/server/api-utils';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   res.setDraftMode({ enable: false });
+
+  // Override cookie header for draft mode for usage in live-preview
+  // https://github.com/vercel/next.js/issues/49927
+  // https://github.com/vercel/next.js/blob/62af2007ce78fdbff33013a8145efbcacbf6b8e2/packages/next/src/server/api-utils/node.ts#L293
+  const headers = res.getHeader('Set-Cookie');
+  if (Array.isArray(headers)) {
+    res.setHeader(
+      'Set-Cookie',
+      headers.map((cookie: string) => {
+        if (cookie.includes(COOKIE_NAME_PRERENDER_BYPASS)) {
+          return cookie.replace('SameSite=Lax', 'SameSite=None; Secure');
+        }
+        return cookie;
+      }),
+    );
+  }
 }

--- a/examples/nextjs-rest/pages/api/disable-draft.ts
+++ b/examples/nextjs-rest/pages/api/disable-draft.ts
@@ -1,5 +1,22 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { COOKIE_NAME_PRERENDER_BYPASS } from 'next/dist/server/api-utils';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   res.setDraftMode({ enable: false });
+
+  // Override cookie header for draft mode for usage in live-preview
+  // https://github.com/vercel/next.js/issues/49927
+  // https://github.com/vercel/next.js/blob/62af2007ce78fdbff33013a8145efbcacbf6b8e2/packages/next/src/server/api-utils/node.ts#L293
+  const headers = res.getHeader('Set-Cookie');
+  if (Array.isArray(headers)) {
+    res.setHeader(
+      'Set-Cookie',
+      headers.map((cookie: string) => {
+        if (cookie.includes(COOKIE_NAME_PRERENDER_BYPASS)) {
+          return cookie.replace('SameSite=Lax', 'SameSite=None; Secure');
+        }
+        return cookie;
+      }),
+    );
+  }
 }

--- a/examples/nextjs-rest/pages/api/draft.ts
+++ b/examples/nextjs-rest/pages/api/draft.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { COOKIE_NAME_PRERENDER_BYPASS } from 'next/dist/server/api-utils';
 import { getPost } from '../../lib/api-rest';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -20,20 +21,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // Enable Draft Mode by setting the cookie
   res.setDraftMode({ enable: true });
+  // Override cookie header for draft mode for usage in live-preview
+  // https://github.com/vercel/next.js/issues/49927
+  // https://github.com/vercel/next.js/blob/62af2007ce78fdbff33013a8145efbcacbf6b8e2/packages/next/src/server/api-utils/node.ts#L293
+  const headers = res.getHeader('Set-Cookie');
+  if (Array.isArray(headers)) {
+    res.setHeader(
+      'Set-Cookie',
+      headers.map((cookie: string) => {
+        if (cookie.includes(COOKIE_NAME_PRERENDER_BYPASS)) {
+          return cookie.replace('SameSite=Lax', 'SameSite=None; Secure');
+        }
+        return cookie;
+      }),
+    );
+  }
 
   // Redirect to the path from the fetched post
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities
   const url = `/posts/${post.fields.slug}`;
-  res.setPreviewData({});
-
-  let previous = res.getHeader('Set-Cookie');
-
-  if (Array.isArray(previous)) {
-    previous = previous.map((cookie: string) => {
-      return cookie.replace('SameSite=Lax', 'SameSite=None;Secure');
-    });
-    res.setHeader('Set-Cookie', previous);
-  }
 
   res.setHeader('Location', url);
   return res.status(307).end();


### PR DESCRIPTION
- Add a note for the workaround in the README.md
- Adjust the workaround to only update the necessary cookie
