### PR TITLE
fix(live-updates): optimize null handling []

### DIFF
--- a/src/graphql/entries.ts
+++ b/src/graphql/entries.ts
@@ -257,7 +257,7 @@ async function updateReferenceEntryField({
     }
 
     const value = reference.fields[key as keyof typeof reference.fields][locale];
-    if (typeof value === 'object') {
+    if (value && typeof value === 'object') {
       if (value.nodeType === 'document') {
         // richtext
         merged[key] = { json: value };

--- a/src/rest/entities.ts
+++ b/src/rest/entities.ts
@@ -43,7 +43,7 @@ async function updateRef(
   for (const key in reference.fields) {
     const value = reference.fields[key as keyof typeof reference.fields][locale];
 
-    if (typeof value === 'object' && value.sys) {
+    if (typeof value === 'object' && value?.sys) {
       await updateSingleRefField(
         result,
         reference,


### PR DESCRIPTION
Handle two cases where `value` could be `null` and `value.sys.id` would throw an error instead of doing updates.
Related to #161