### PR TITLE
fix(graphql): fields not updating when creating a new entry [TOL-1251]

### DIFF
--- a/src/__tests__/liveUpdates.spec.ts
+++ b/src/__tests__/liveUpdates.spec.ts
@@ -196,11 +196,25 @@ describe('LiveUpdates', () => {
     });
 
     const expected = helpers.clone(nestedCollectionFromPreviewApp);
+    // updated fields
     expected.items[0].menuItemsCollection.items[2].featuredPagesCollection.items[1].pageName =
       pageInsideCollectionFromEntryEditor.fields.pageName[locale];
     expected.items[0].menuItemsCollection.items[2].featuredPagesCollection.items[1].slug =
       pageInsideCollectionFromEntryEditor.fields.slug[locale];
+    // new fields
+    (
+      expected.items[0].menuItemsCollection.items[2].featuredPagesCollection.items[1] as any
+    ).internalName = 'Testing';
+    (
+      expected.items[0].menuItemsCollection.items[2].featuredPagesCollection.items[1] as any
+    ).extraSectionCollection = { items: [] };
+    (expected.items[0].menuItemsCollection.items[2].featuredPagesCollection.items[1] as any).seo =
+      null;
+    (
+      expected.items[0].menuItemsCollection.items[2].featuredPagesCollection.items[1] as any
+    ).topSectionCollection = { items: [] };
 
+    expect(callback).toHaveBeenCalled();
     expect(callback).toHaveBeenCalledWith(expected);
   });
 

--- a/src/graphql/__tests__/entries.test.ts
+++ b/src/graphql/__tests__/entries.test.ts
@@ -13,6 +13,7 @@ const EN = 'en-US';
 vi.mock('../../helpers/debug');
 vi.mock('../../helpers/resolveReference');
 
+// Note: we can get rid of expect.objectContaining, if we iterate over the provided data instead of the ContentType.fields
 describe('Update GraphQL Entry', () => {
   const testReferenceId = '18kDTlnJNnDIJf6PsXE5Mr';
 
@@ -61,7 +62,13 @@ describe('Update GraphQL Entry', () => {
   it('keeps __typename unchanged', async () => {
     const data = { __typename: 'CT', shortText: 'text', sys: { id: 'abc' } };
 
-    const update = await updateFn({ data });
+    const update = await updateFn({
+      data,
+      contentType: {
+        sys: { id: 'abc' },
+        fields: [{ name: 'shortText', type: 'Symbol' }],
+      } as unknown as ContentType,
+    });
 
     expect(update).toEqual(
       expect.objectContaining({
@@ -94,20 +101,22 @@ describe('Update GraphQL Entry', () => {
 
     const result = await updateFn({ data });
 
-    expect(result).toEqual({
-      shortText: entry.fields.shortText[EN],
-      shortTextList: entry.fields.shortTextList[EN],
-      longText: entry.fields.longText[EN],
-      boolean: entry.fields.boolean[EN],
-      numberInteger: entry.fields.numberInteger[EN],
-      numberDecimal: entry.fields.numberDecimal[EN],
-      dateTime: entry.fields.dateTime[EN],
-      location: entry.fields.location[EN],
-      json: entry.fields.json[EN],
-      sys: {
-        id: entry.sys.id,
-      },
-    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        shortText: entry.fields.shortText[EN],
+        shortTextList: entry.fields.shortTextList[EN],
+        longText: entry.fields.longText[EN],
+        boolean: entry.fields.boolean[EN],
+        numberInteger: entry.fields.numberInteger[EN],
+        numberDecimal: entry.fields.numberDecimal[EN],
+        dateTime: entry.fields.dateTime[EN],
+        location: entry.fields.location[EN],
+        json: entry.fields.json[EN],
+        sys: {
+          id: entry.sys.id,
+        },
+      })
+    );
   });
 
   describe('single reference fields', () => {
@@ -139,20 +148,22 @@ describe('Update GraphQL Entry', () => {
 
         const result = await updateFn({ data, update });
 
-        expect(result).toEqual({
-          __typename: 'Page',
-          sys: {
-            id: entry.sys.id,
-          },
-          reference: {
-            __typename: 'TestContentType',
+        expect(result).toEqual(
+          expect.objectContaining({
+            __typename: 'Page',
             sys: {
-              id: testReferenceId,
-              linkType: 'Entry',
-              type: 'Link',
+              id: entry.sys.id,
             },
-          },
-        });
+            reference: {
+              __typename: 'TestContentType',
+              sys: {
+                id: testReferenceId,
+                linkType: 'Entry',
+                type: 'Link',
+              },
+            },
+          })
+        );
       });
 
       it('if reference is not in entityReferenceMap but has a __typename it does not call resolveReference', async () => {
@@ -184,20 +195,22 @@ describe('Update GraphQL Entry', () => {
 
         const result = await updateFn({ data, update });
 
-        expect(result).toEqual({
-          __typename: 'Page',
-          sys: {
-            id: entry.sys.id,
-          },
-          reference: {
-            __typename: 'TestContentType',
+        expect(result).toEqual(
+          expect.objectContaining({
+            __typename: 'Page',
             sys: {
-              id: testAddingEntryId,
-              linkType: 'Entry',
-              type: 'Link',
+              id: entry.sys.id,
             },
-          },
-        });
+            reference: {
+              __typename: 'TestContentType',
+              sys: {
+                id: testAddingEntryId,
+                linkType: 'Entry',
+                type: 'Link',
+              },
+            },
+          })
+        );
 
         expect(resolveReference).not.toHaveBeenCalled();
       });
@@ -236,22 +249,24 @@ describe('Update GraphQL Entry', () => {
 
         const result = await updateFn({ data, update });
 
-        expect(result).toEqual({
-          __typename: 'Page',
-          sys: {
-            id: entry.sys.id,
-          },
-          reference: {
-            // content type has been adjusted to have capital letter at the start
-            __typename: 'TestContentType',
+        expect(result).toEqual(
+          expect.objectContaining({
+            __typename: 'Page',
             sys: {
-              id: testReferenceId,
-              linkType: 'Entry',
-              type: 'Link',
+              id: entry.sys.id,
             },
-            propertyShouldStay: 'value',
-          },
-        });
+            reference: {
+              // content type has been adjusted to have capital letter at the start
+              __typename: 'TestContentType',
+              sys: {
+                id: testReferenceId,
+                linkType: 'Entry',
+                type: 'Link',
+              },
+              propertyShouldStay: 'value',
+            },
+          })
+        );
       });
     });
 
@@ -359,24 +374,26 @@ describe('Update GraphQL Entry', () => {
 
       const result = await updateFn({ data, update });
 
-      expect(result).toEqual({
-        __typename: 'Page',
-        sys: {
-          id: entry.sys.id,
-        },
-        referenceManyCollection: {
-          items: [
-            {
-              __typename: 'TestContentTypeForManyRef',
-              sys: {
-                id: testAddingEntryId,
-                linkType: 'Entry',
-                type: 'Link',
+      expect(result).toEqual(
+        expect.objectContaining({
+          __typename: 'Page',
+          sys: {
+            id: entry.sys.id,
+          },
+          referenceManyCollection: {
+            items: [
+              {
+                __typename: 'TestContentTypeForManyRef',
+                sys: {
+                  id: testAddingEntryId,
+                  linkType: 'Entry',
+                  type: 'Link',
+                },
               },
-            },
-          ],
-        },
-      });
+            ],
+          },
+        })
+      );
     });
 
     it('if reference is not in entityReferenceMap but has a __typename it does not call resolveReference', async () => {
@@ -412,24 +429,26 @@ describe('Update GraphQL Entry', () => {
 
       const result = await updateFn({ data, update });
 
-      expect(result).toEqual({
-        __typename: 'Page',
-        sys: {
-          id: entry.sys.id,
-        },
-        referenceManyCollection: {
-          items: [
-            {
-              __typename: 'TestContentTypeForManyRef',
-              sys: {
-                id: testAddingEntryId,
-                linkType: 'Entry',
-                type: 'Link',
+      expect(result).toEqual(
+        expect.objectContaining({
+          __typename: 'Page',
+          sys: {
+            id: entry.sys.id,
+          },
+          referenceManyCollection: {
+            items: [
+              {
+                __typename: 'TestContentTypeForManyRef',
+                sys: {
+                  id: testAddingEntryId,
+                  linkType: 'Entry',
+                  type: 'Link',
+                },
               },
-            },
-          ],
-        },
-      });
+            ],
+          },
+        })
+      );
 
       expect(resolveReference).not.toHaveBeenCalled();
     });
@@ -476,27 +495,32 @@ describe('Update GraphQL Entry', () => {
         },
       } as unknown as EntryProps<KeyValueMap>;
 
-      const result = await updateFn({ data, update });
-
-      expect(result).toEqual({
-        __typename: 'Page',
-        sys: {
-          id: entry.sys.id,
-        },
-        referenceManyCollection: {
-          items: [
-            {
-              __typename: 'TestContentTypeForManyRef',
-              sys: {
-                id: testAddingEntryId,
-                linkType: 'Entry',
-                type: 'Link',
-              },
-              propertyShouldStay: 'value',
-            },
-          ],
-        },
+      const result = await updateFn({
+        data,
+        update,
       });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          __typename: 'Page',
+          sys: {
+            id: entry.sys.id,
+          },
+          referenceManyCollection: {
+            items: [
+              {
+                __typename: 'TestContentTypeForManyRef',
+                sys: {
+                  id: testAddingEntryId,
+                  linkType: 'Entry',
+                  type: 'Link',
+                },
+                propertyShouldStay: 'value',
+              },
+            ],
+          },
+        })
+      );
     });
   });
 
@@ -508,7 +532,14 @@ describe('Update GraphQL Entry', () => {
       },
     };
 
-    const result = await updateFn({ data, locale: 'n/a' });
+    const result = await updateFn({
+      data,
+      locale: 'n/a',
+      contentType: {
+        sys: defaultContentType.sys,
+        fields: [{ name: 'shortText', type: 'Symbol' }],
+      } as unknown as ContentType,
+    });
 
     expect(result).toEqual({
       shortText: null,

--- a/src/graphql/__tests__/queryUtils.test.ts
+++ b/src/graphql/__tests__/queryUtils.test.ts
@@ -74,35 +74,20 @@ describe('updateAliasedInformation', () => {
 });
 
 describe('isRelevantField', () => {
-  it('validates the information based on the provided data', () => {
-    const data = {
-      sys: { id: '1' },
-      name: 'Test',
-      content: {},
-      topSectionCollection: { items: [] },
-    };
-
-    // direct match => true
-    expect(isRelevantField('content', 'pageCollection', data)).toBeTruthy();
-    // collection match => true
-    expect(isRelevantField('topSection', 'pageCollection', data)).toBeTruthy();
-    // unknown alias => false
-    expect(isRelevantField('internalName', 'pageCollection', data)).toBeFalsy();
-    // unknown field => false
-    expect(isRelevantField('header', 'pageCollection', data)).toBeFalsy();
+  it('returns true because no are queryParams provided', () => {
+    expect(isRelevantField('content', 'pageCollection')).toBeTruthy();
   });
 
   it('validates the information based on the provided queryParams', () => {
-    const data = {};
     const gqlParams = parseGraphQLParams(query);
 
     // direct match => true
-    expect(isRelevantField('content', 'pageCollection', data, gqlParams)).toBeTruthy();
+    expect(isRelevantField('content', 'pageCollection', gqlParams)).toBeTruthy();
     // collection match => true
-    expect(isRelevantField('topSection', 'pageCollection', data, gqlParams)).toBeTruthy();
+    expect(isRelevantField('topSection', 'pageCollection', gqlParams)).toBeTruthy();
     // unknown alias => false
-    expect(isRelevantField('internalName', 'pageCollection', data, gqlParams)).toBeTruthy();
+    expect(isRelevantField('internalName', 'pageCollection', gqlParams)).toBeTruthy();
     // unknown field => false
-    expect(isRelevantField('header', 'pageCollection', data, gqlParams)).toBeFalsy();
+    expect(isRelevantField('header', 'pageCollection', gqlParams)).toBeFalsy();
   });
 });

--- a/src/graphql/__tests__/queryUtils.test.ts
+++ b/src/graphql/__tests__/queryUtils.test.ts
@@ -74,7 +74,7 @@ describe('updateAliasedInformation', () => {
 });
 
 describe('isRelevantField', () => {
-  it('returns true because no are queryParams provided', () => {
+  it('returns true because no queryParams are provided', () => {
     expect(isRelevantField('content', 'pageCollection')).toBeTruthy();
   });
 

--- a/src/graphql/entries.ts
+++ b/src/graphql/entries.ts
@@ -49,8 +49,7 @@ export async function updateEntry({
 
   for (const field of contentType.fields) {
     const name = field.apiName ?? field.name;
-
-    if (isRelevantField(name, typename, copyOfDataFromPreviewApp, gqlParams)) {
+    if (isRelevantField(name, typename, gqlParams)) {
       if (isPrimitiveField(field)) {
         updatePrimitiveField({
           dataFromPreviewApp: copyOfDataFromPreviewApp,
@@ -167,7 +166,7 @@ async function processNode(
 }
 
 async function processRichTextField(
-  richTextNode: any,
+  richTextNode: any | null,
   entityReferenceMap: EntityReferenceMap,
   locale: string,
   gqlParams?: GraphQLParams
@@ -175,8 +174,10 @@ async function processRichTextField(
   const entries: RichTextLink = { block: [], inline: [] };
   const assets: RichTextLink = { block: [], inline: [] };
 
-  for (const node of richTextNode.content) {
-    await processNode(node, entries, assets, entityReferenceMap, locale, gqlParams);
+  if (richTextNode) {
+    for (const node of richTextNode.content) {
+      await processNode(node, entries, assets, entityReferenceMap, locale, gqlParams);
+    }
   }
 
   return {
@@ -252,7 +253,7 @@ async function updateReferenceEntryField({
 
   // TODO: kind of duplication with line 46, check if we can combine them
   for (const key in reference.fields) {
-    if (!isRelevantField(key, typeName, reference.fields, gqlParams)) {
+    if (!isRelevantField(key, typeName, gqlParams)) {
       continue;
     }
 

--- a/src/graphql/queryUtils.ts
+++ b/src/graphql/queryUtils.ts
@@ -1,7 +1,7 @@
 import type { DocumentNode, SelectionNode } from 'graphql';
 
 import { debug } from '../helpers';
-import type { Entity, GraphQLParams } from '../types';
+import type { GraphQLParams } from '../types';
 import { buildCollectionName } from './utils';
 interface GeneratedGraphQLStructure {
   name: string;
@@ -84,18 +84,17 @@ export function parseGraphQLParams(query: DocumentNode): GraphQLParams {
 /**
  * Checks if the current field is relevant for the update processing.
  * This speeds up the update time especially for references and prevents wrong-positives when working with alias.
- * If used without the GraphQL query information, it checks only if the data is defined on the given data structure.
+ * If used without the GraphQL query information, it will always return `true`.
  */
 export function isRelevantField(
   name: string,
   typename: string,
-  data: Entity,
   gqlParams?: GraphQLParams
 ): boolean {
   const collectionName = buildCollectionName(name);
 
   if (!gqlParams) {
-    return name in data || collectionName in data;
+    return true;
   }
 
   const queryInformation = gqlParams.get(typename);

--- a/src/liveUpdates.ts
+++ b/src/liveUpdates.ts
@@ -62,22 +62,19 @@ export class LiveUpdates {
   }> {
     if ('__typename' in dataFromPreviewApp) {
       // GraphQL
-      if (dataFromPreviewApp.__typename === 'Asset') {
-        return {
-          data: gql.updateAsset(dataFromPreviewApp, updateFromEntryEditor as AssetProps, locale),
-          updated: true,
-        };
-      }
+      const data = await (dataFromPreviewApp.__typename === 'Asset'
+        ? gql.updateAsset(dataFromPreviewApp, updateFromEntryEditor as AssetProps, locale)
+        : gql.updateEntry({
+            contentType,
+            dataFromPreviewApp,
+            updateFromEntryEditor: updateFromEntryEditor as EntryProps,
+            locale,
+            entityReferenceMap,
+            gqlParams,
+          }));
 
       return {
-        data: await gql.updateEntry({
-          contentType,
-          dataFromPreviewApp,
-          updateFromEntryEditor: updateFromEntryEditor as EntryProps,
-          locale,
-          entityReferenceMap,
-          gqlParams,
-        }),
+        data,
         updated: true,
       };
     }


### PR DESCRIPTION
- Fields were not updated for GraphQL if the entry was newly generated.
This was because of the `isRelevantField` implementation, now it updates every field, which produces some adjustments in the tests.
- "cannot read content of null" due a missing `null` type on `richTextNode`