### PR TITLE
fix: updateRef embedded entries REST [TOL-1263]

### DIFF
--- a/src/rest/entities.ts
+++ b/src/rest/entities.ts
@@ -21,7 +21,7 @@ function getFieldName(contentType: ContentType, field: ContentType['fields'][num
  * Update the reference from the entry editor with the information from the entityReferenceMap.
  * If the information is not yet available, it send a message to the editor to retrieve it.
  */
-async function updateRef(
+export async function updateRef(
   dataFromPreviewApp: Reference | undefined,
   updateFromEntryEditor: Reference | SysLink,
   locale: string,

--- a/src/rest/entities.ts
+++ b/src/rest/entities.ts
@@ -59,6 +59,8 @@ async function updateRef(
         key as keyof Reference['fields'],
         entityReferenceMap
       );
+    } else if (value.content && value.nodeType === 'document') {
+      await updateRichTextField(result, reference, key, locale, entityReferenceMap);
     } else {
       updatePrimitiveField({
         dataFromPreviewApp: result.fields,


### PR DESCRIPTION
The updateRef function inside entities.ts for REST was not specifically handling 'RichText'.
It was only checking if the field's value is an object or an array of objects with sys property (indicating it's a reference to another Contentful entity), and then either updates a single reference field (updateSingleRefField) or multiple reference fields (updateMultiRefField). We also handle primitive fields, which just replaces the entity with the update (which is what happens currently with the Rich Text field). So it did not have specific logic to handle 'RichText' and its embedded entries.