### PR TITLE
fix: graphql embedded entries hyperlinks [TOL-1262]

### DIFF
--- a/src/rest/entities.ts
+++ b/src/rest/entities.ts
@@ -1,7 +1,7 @@
 import { BLOCKS, INLINES } from '@contentful/rich-text-types';
 import type { AssetProps, EntryProps, KeyValueMap, SysLink } from 'contentful-management';
 
-import { clone, isPrimitiveField, resolveReference, updatePrimitiveField } from '../helpers';
+import { debug, clone, isPrimitiveField, resolveReference, updatePrimitiveField } from '../helpers';
 import { ContentType, EntityReferenceMap, isAsset } from '../types';
 
 type Reference = AssetProps | EntryProps;
@@ -151,6 +151,10 @@ async function resolveRichTextLinks(
         node.data.target = await updateRef(undefined, updatedReference, locale, entityReferenceMap);
       }
     }
+  } else {
+    debug.warn('Unhandled nodeType in embedded entries in rich text', {
+      nodeType: node.nodeType,
+    });
   }
   if (node.content) {
     for (const childNode of node.content) {


### PR DESCRIPTION
- fix an issue with entry and asset hyperlinks with graphql (fixes https://github.com/contentful/live-preview/issues/179)
- use rich text types package to determine the types
- add missing debug warn in REST version when we are handling an unknown embedded entry type


https://github.com/contentful/live-preview/assets/22968325/b792f2b2-64e5-4c6a-bc87-e6e4894c605a