### PR TITLE
fix: circular references and infinite loop problems

### DIFF
--- a/packages/live-preview-sdk/package.json
+++ b/packages/live-preview-sdk/package.json
@@ -51,10 +51,11 @@
   "dependencies": {
     "@contentful/rich-text-types": "^16.2.0",
     "@contentful/visual-sdk": "^1.0.0-alpha.1",
-    "use-deep-compare-effect": "^1.8.1"
+    "lodash.isequal": "^4.5.0"
   },
   "devDependencies": {
     "@testing-library/react": "14.0.0",
+    "@types/lodash.isequal": "^4.5.6",
     "@types/node": "^20.1.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",

--- a/packages/live-preview-sdk/src/rest/__tests__/entities.test.ts
+++ b/packages/live-preview-sdk/src/rest/__tests__/entities.test.ts
@@ -65,12 +65,16 @@ describe('Update REST entry', () => {
     locale?: string;
     entityReferenceMap?: EntityReferenceMap;
   }) => {
+    const visitedReferences = new Set<string>();
+
     return updateEntity(
       contentType,
       clone(dataFromPreviewApp),
       clone(updateFromEntryEditor),
       locale,
-      entityReferenceMap
+      entityReferenceMap,
+      0,
+      visitedReferences,
     );
   };
 
@@ -118,7 +122,7 @@ describe('Update REST entry', () => {
       });
 
       expect(result).toEqual(
-        patchField(defaultResult, 'refOneSameSpace', newEntryReferenceTransformed)
+        patchField(defaultResult, 'refOneSameSpace', newEntryReferenceTransformed),
       );
     });
 
@@ -134,7 +138,7 @@ describe('Update REST entry', () => {
         patchField(defaultResult, 'refManySameSpace', [
           newEntryReferenceTransformed,
           newAssetReferenceTransformed,
-        ])
+        ]),
       );
     });
 
@@ -153,7 +157,7 @@ describe('Update REST entry', () => {
         patchField(defaultResult, 'refManySameSpace', [
           newAssetReferenceTransformed,
           newEntryReferenceTransformed,
-        ])
+        ]),
       );
     });
 
@@ -169,7 +173,7 @@ describe('Update REST entry', () => {
       });
 
       expect(result).toEqual(
-        patchField(defaultResult, 'refManySameSpace', [newEntryReferenceTransformed])
+        patchField(defaultResult, 'refManySameSpace', [newEntryReferenceTransformed]),
       );
     });
 


### PR DESCRIPTION
### This PR fixes multiple issues:
- We were using the`useDeepCompareEffectNoCheck` package, which has a dependency on dequal package. Dequal has an issue with infinite loops in circular references: https://github.com/lukeed/dequal/issues/19 . I removed this package in favour of the is isEqual package from lodash. This one seems to work better with circular references.
- Even with the previously introduced depth limitation for REST (https://github.com/contentful/live-preview/pull/195), you could still encounter infinite loops if an entity links to itself directly or indirectly. Now, when a circular reference is detected, it does not update the reference further. Instead, it returns the the already updated reference from the `entityReferenceMap`
- There was an issue with resource links being wrongly detected as normal references. I've added some todo's for follow up PRs to implement the live update behaviour for resource links.

### Screenshots
Before:
<img width="1728" alt="Screenshot 2023-07-13 at 10 53 15" src="https://github.com/contentful/live-preview/assets/22968325/df3283e3-53dd-4604-a2b2-bc3d75c3d3a2">

After:
<img width="1728" alt="Screenshot 2023-07-13 at 10 56 54" src="https://github.com/contentful/live-preview/assets/22968325/0600ee8e-65cd-4517-bf31-8aa5b6769cdd">
