### PR TITLE
chore: allow react 17 for peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Live preview SDK for both the inspector mode connection + live content updates b
 ### Requirements
 
 - Node.js: `>=16.15.1`
+- React.js `>=17`
 
 To install live preview simply run one of the following commands.
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "husky install",
     "build": "lerna run build",
     "start": "lerna run --stream start",
-    "prepublishOnly": "lerna run build",
+    "prepublish": "lerna run build",
     "cm": "git-cz"
   },
   "dependencies": {},

--- a/packages/live-preview-sdk/package.json
+++ b/packages/live-preview-sdk/package.json
@@ -45,7 +45,7 @@
     "test": "vitest",
     "test:ci": "vitest run",
     "coverage": "vitest run --coverage",
-    "prepublishOnly": "yarn build"
+    "prepublish": "yarn build"
   },
   "homepage": "https://github.com/contentful/live-preview#readme",
   "dependencies": {
@@ -72,7 +72,7 @@
     "vitest": "^0.33.0"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   }
 }


### PR DESCRIPTION
As we don't use any react 18 specific code, there speaks nothing against adding version 17 of react to the peer dependencies