### PR TITLE
fix(types): optimize export of typings

### DIFF
--- a/packages/live-preview-sdk/src/__tests__/inspectorMode.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/inspectorMode.spec.ts
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 
+import { LIVE_PREVIEW_EDITOR_SOURCE } from '../constants';
 import { InspectorMode } from '../inspectorMode';
-import { LivePreviewPostMessageMethods } from '../types';
+import { LivePreviewPostMessageMethods } from '../messages';
 
 const locale = 'en-US';
 
@@ -34,7 +35,7 @@ describe('InspectorMode', () => {
         action: LivePreviewPostMessageMethods.INSPECTOR_MODE_CHANGED,
         from: 'live-preview',
         method: LivePreviewPostMessageMethods.INSPECTOR_MODE_CHANGED,
-        source: 'live-preview-app',
+        source: LIVE_PREVIEW_EDITOR_SOURCE,
         isInspectorActive: true,
       });
       expect(spy).toHaveBeenCalledWith('contentful-inspector--active', true);

--- a/packages/live-preview-sdk/src/__tests__/liveUpdates.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/liveUpdates.spec.ts
@@ -2,9 +2,11 @@
 import { AssetProps, EntryProps } from 'contentful-management';
 import { describe, it, vi, expect, beforeEach, afterEach } from 'vitest';
 
+import { LIVE_PREVIEW_EDITOR_SOURCE } from '../constants';
 import * as helpers from '../helpers';
 import { LiveUpdates } from '../liveUpdates';
-import { ContentType, LivePreviewPostMessageMethods } from '../types';
+import { LivePreviewPostMessageMethods } from '../messages';
+import { ContentType } from '../types';
 import assetFromEntryEditor from './fixtures/assetFromEntryEditor.json';
 import landingPageContentType from './fixtures/landingPageContentType.json';
 import nestedCollectionFromPreviewApp from './fixtures/nestedCollectionFromPreviewApp.json';
@@ -64,7 +66,7 @@ describe('LiveUpdates', () => {
       action: LivePreviewPostMessageMethods.ENTRY_UPDATED,
       from: 'live-preview',
       method: LivePreviewPostMessageMethods.ENTRY_UPDATED,
-      source: 'live-preview-app',
+      source: LIVE_PREVIEW_EDITOR_SOURCE,
       entityReferenceMap: new Map(),
     });
 
@@ -80,7 +82,7 @@ describe('LiveUpdates', () => {
       action: LivePreviewPostMessageMethods.ENTRY_UPDATED,
       from: 'live-preview',
       method: LivePreviewPostMessageMethods.ENTRY_UPDATED,
-      source: 'live-preview-app',
+      source: LIVE_PREVIEW_EDITOR_SOURCE,
       entityReferenceMap: new Map(),
     });
 
@@ -118,7 +120,7 @@ describe('LiveUpdates', () => {
       action: LivePreviewPostMessageMethods.ENTRY_UPDATED,
       from: 'live-preview',
       method: LivePreviewPostMessageMethods.ENTRY_UPDATED,
-      source: 'live-preview-app',
+      source: LIVE_PREVIEW_EDITOR_SOURCE,
       entityReferenceMap: new Map(),
     });
 
@@ -132,7 +134,7 @@ describe('LiveUpdates', () => {
       action: LivePreviewPostMessageMethods.ENTRY_UPDATED,
       from: 'live-preview',
       method: LivePreviewPostMessageMethods.ENTRY_UPDATED,
-      source: 'live-preview-app',
+      source: LIVE_PREVIEW_EDITOR_SOURCE,
       entityReferenceMap: new Map(),
     });
 
@@ -150,7 +152,7 @@ describe('LiveUpdates', () => {
       action: LivePreviewPostMessageMethods.INSPECTOR_MODE_CHANGED,
       method: LivePreviewPostMessageMethods.INSPECTOR_MODE_CHANGED,
       from: 'live-preview',
-      source: 'live-preview-app',
+      source: LIVE_PREVIEW_EDITOR_SOURCE,
     });
 
     expect(callback).not.toHaveBeenCalled();
@@ -168,7 +170,7 @@ describe('LiveUpdates', () => {
       action: LivePreviewPostMessageMethods.ENTRY_UPDATED,
       from: 'live-preview',
       method: LivePreviewPostMessageMethods.ENTRY_UPDATED,
-      source: 'live-preview-app',
+      source: LIVE_PREVIEW_EDITOR_SOURCE,
       entityReferenceMap: new Map(),
     });
 
@@ -184,7 +186,7 @@ describe('LiveUpdates', () => {
       action: LivePreviewPostMessageMethods.ENTRY_UPDATED,
       from: 'live-preview',
       method: LivePreviewPostMessageMethods.ENTRY_UPDATED,
-      source: 'live-preview-app',
+      source: LIVE_PREVIEW_EDITOR_SOURCE,
       entityReferenceMap: new Map(),
       contentType: {} as unknown as ContentType,
     });
@@ -207,7 +209,7 @@ describe('LiveUpdates', () => {
       action: LivePreviewPostMessageMethods.ENTRY_UPDATED,
       from: 'live-preview',
       method: LivePreviewPostMessageMethods.ENTRY_UPDATED,
-      source: 'live-preview-app',
+      source: LIVE_PREVIEW_EDITOR_SOURCE,
       entityReferenceMap: new Map(),
     });
 

--- a/packages/live-preview-sdk/src/__tests__/validateMessages.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/validateMessages.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+import { LIVE_PREVIEW_EDITOR_SOURCE } from '../constants';
+import { isValidMessage } from '../helpers/validateMessage';
+
+describe('isValidMessage', () => {
+  it('should return false because the event.data is missing', () => {
+    expect(isValidMessage({} as unknown as MessageEvent)).toBeFalsy();
+  });
+  it('should return false because the event.data is not JSON', () => {
+    expect(isValidMessage({ data: 'string' } as MessageEvent)).toBeFalsy();
+  });
+  it('should return false because the event.source is wrong', () => {
+    expect(
+      isValidMessage({ data: { any: 'data', source: 'webpack' } } as MessageEvent)
+    ).toBeFalsy();
+  });
+  it('should return false because the event.from is wrong', () => {
+    expect(isValidMessage({ data: { any: 'data', from: 'webpack' } } as MessageEvent)).toBeFalsy();
+  });
+  it('should return false because neither event.from and event.source is provided', () => {
+    expect(isValidMessage({ data: { any: 'data' } } as MessageEvent)).toBeFalsy();
+  });
+  it('should return true because the event.source is valid', () => {
+    expect(
+      isValidMessage({ data: { any: 'data', source: LIVE_PREVIEW_EDITOR_SOURCE } } as MessageEvent)
+    ).toBeTruthy();
+  });
+  it('should return true because the event.from is valid', () => {
+    expect(
+      isValidMessage({ data: { any: 'data', from: 'live-preview' } } as MessageEvent)
+    ).toBeTruthy();
+  });
+});

--- a/packages/live-preview-sdk/src/constants.ts
+++ b/packages/live-preview-sdk/src/constants.ts
@@ -9,3 +9,6 @@ export const TOOLTIP_HEIGHT = 32;
 export const TOOLTIP_PADDING_LEFT = 5;
 
 export const MAX_DEPTH = 5;
+
+export const LIVE_PREVIEW_EDITOR_SOURCE = 'live-preview-editor' as const;
+export const LIVE_PREVIEW_SDK_SOURCE = 'live-preview-sdk' as const;

--- a/packages/live-preview-sdk/src/helpers/utils.ts
+++ b/packages/live-preview-sdk/src/helpers/utils.ts
@@ -1,5 +1,6 @@
 import * as packageJson from '../../package.json';
-import type { EditorMessage, PostMessageMethods, MessageFromSDK } from '../types';
+import { PostMessageMethods } from '../messages';
+import type { EditorMessage, MessageFromSDK } from '../messages';
 import { debug } from './debug';
 
 /**

--- a/packages/live-preview-sdk/src/helpers/validateMessage.ts
+++ b/packages/live-preview-sdk/src/helpers/validateMessage.ts
@@ -1,0 +1,17 @@
+import { LIVE_PREVIEW_EDITOR_SOURCE } from '../constants';
+
+export function isValidMessage(event: MessageEvent<unknown>): boolean {
+  if (typeof event.data !== 'object' || !event.data) {
+    return false;
+  }
+
+  if ('from' in event.data && event.data.from === 'live-preview') {
+    return true;
+  }
+
+  if ('source' in event.data && event.data.source === LIVE_PREVIEW_EDITOR_SOURCE) {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/live-preview-sdk/src/index.ts
+++ b/packages/live-preview-sdk/src/index.ts
@@ -1,6 +1,6 @@
 import './styles.css';
 
-import type { DocumentNode } from 'graphql';
+import { type DocumentNode } from 'graphql';
 
 import {
   sendMessageToEditor,
@@ -9,14 +9,14 @@ import {
   debug,
   isInsideIframe,
 } from './helpers';
+import { isValidMessage } from './helpers/validateMessage';
 import { InspectorMode } from './inspectorMode';
 import { LiveUpdates } from './liveUpdates';
+import { LivePreviewPostMessageMethods, MessageFromEditor } from './messages';
 import {
   Argument,
   InspectorModeTags,
-  LivePreviewPostMessageMethods,
   LivePreviewProps,
-  MessageFromEditor,
   SubscribeCallback,
   TagAttributes,
 } from './types';
@@ -94,8 +94,9 @@ export class ContentfulLivePreview {
 
       // bind event listeners for interactivity
       window.addEventListener('message', (event: MessageEvent<MessageFromEditor>) => {
-        if (typeof event.data !== 'object' || !event.data) return;
-        if (event.data.from !== 'live-preview') return;
+        if (!isValidMessage(event)) {
+          return;
+        }
 
         debug.log('Received message', event.data);
 
@@ -124,6 +125,7 @@ export class ContentfulLivePreview {
       });
 
       // tell the editor that there's a SDK
+      // TODO: switch to CONNECTED event once the editor supports it
       sendMessageToEditor(LivePreviewPostMessageMethods.IFRAME_CONNECTED, {
         action: LivePreviewPostMessageMethods.IFRAME_CONNECTED,
         connected: true,
@@ -182,3 +184,6 @@ export class ContentfulLivePreview {
     return this.liveUpdatesEnabled;
   }
 }
+
+export { LIVE_PREVIEW_EDITOR_SOURCE, LIVE_PREVIEW_SDK_SOURCE } from './constants';
+export * from './messages';

--- a/packages/live-preview-sdk/src/inspectorMode.ts
+++ b/packages/live-preview-sdk/src/inspectorMode.ts
@@ -8,11 +8,11 @@ import {
 } from './constants';
 import { sendMessageToEditor } from './helpers';
 import {
-  InspectorModeChanged,
+  InspectorModeChangedMessage,
   LivePreviewPostMessageMethods,
   MessageFromEditor,
-  TagAttributes,
-} from './types';
+} from './messages';
+import { TagAttributes } from './types';
 
 export class InspectorMode {
   private tooltip: HTMLButtonElement | null = null; // this tooltip scrolls to the correct field in the entry editor
@@ -43,7 +43,7 @@ export class InspectorMode {
       // Toggle the contentful-inspector--active class on the body element based on the isInspectorActive boolean
       document.body.classList.toggle(
         'contentful-inspector--active',
-        (data as InspectorModeChanged).isInspectorActive
+        (data as InspectorModeChangedMessage).isInspectorActive
       );
     }
   }

--- a/packages/live-preview-sdk/src/liveUpdates.ts
+++ b/packages/live-preview-sdk/src/liveUpdates.ts
@@ -1,10 +1,11 @@
 import type { AssetProps, EntryProps } from 'contentful-management';
 
-import { ContentfulSubscribeConfig } from '.';
+import type { ContentfulSubscribeConfig, EntryUpdatedMessage, MessageFromEditor } from '.';
 import * as gql from './graphql';
 import { parseGraphQLParams } from './graphql/queryUtils';
 import { clone, generateUID, sendMessageToEditor, StorageMap, debug } from './helpers';
 import { validateDataForLiveUpdates } from './helpers/validation';
+import { LivePreviewPostMessageMethods } from './messages';
 import * as rest from './rest';
 import {
   Argument,
@@ -14,10 +15,7 @@ import {
   EntityReferenceMap,
   hasSysInformation,
   Subscription,
-  MessageFromEditor,
-  EntryUpdatedMessage,
   GraphQLParams,
-  LivePreviewPostMessageMethods,
 } from './types';
 
 interface MergeEntityProps {

--- a/packages/live-preview-sdk/src/messages.ts
+++ b/packages/live-preview-sdk/src/messages.ts
@@ -1,0 +1,143 @@
+import type { RequestEntitiesMessage, RequestedEntitiesMessage } from '@contentful/visual-sdk';
+import { PostMessageMethods as StorePostMessageMethods } from '@contentful/visual-sdk';
+import type { AssetProps, EntryProps, SysLink } from 'contentful-management';
+
+import type { LIVE_PREVIEW_EDITOR_SOURCE, LIVE_PREVIEW_SDK_SOURCE } from './constants';
+import type { ContentType, EntityReferenceMap } from './types';
+
+enum LivePreviewPostMessageMethods {
+  CONNECTED = 'CONNECTED',
+  DISCONNECTED = 'DISCONNECTED',
+  /**
+   * @deprecated use `LivePreviewPostMessageMethods.CONNECTED` instead
+   */
+  IFRAME_CONNECTED = 'IFRAME_CONNECTED',
+  TAGGED_FIELD_CLICKED = 'TAGGED_FIELD_CLICKED',
+  URL_CHANGED = 'URL_CHANGED',
+  SUBSCRIBED = 'SUBSCRIBED',
+
+  ENTRY_UPDATED = 'ENTRY_UPDATED',
+  ENTRY_SAVED = 'ENTRY_SAVED',
+  INSPECTOR_MODE_CHANGED = 'INSPECTOR_MODE_CHANGED',
+  DEBUG_MODE_ENABLED = 'DEBUG_MODE_ENABLED',
+
+  /**
+   * @deprecated use PostMessageStoreMethods instead
+   */
+  ENTITY_NOT_KNOWN = 'ENTITY_NOT_KNOWN',
+  /**
+   * @deprecated use PostMessageStoreMethods instead
+   */
+  UNKNOWN_REFERENCE_LOADED = 'UNKNOWN_REFERENCE_LOADED',
+}
+
+export {
+  StorePostMessageMethods,
+  LivePreviewPostMessageMethods,
+  RequestEntitiesMessage,
+  RequestedEntitiesMessage,
+};
+export type PostMessageMethods = LivePreviewPostMessageMethods | StorePostMessageMethods;
+
+export type ConnectedMessage = {
+  /** @deprecated use method instead */
+  action: LivePreviewPostMessageMethods.IFRAME_CONNECTED | LivePreviewPostMessageMethods.CONNECTED;
+  connected: true;
+  tags: number;
+  locale: string;
+};
+
+export type TaggedFieldClickMessage = {
+  /** @deprecated use method instead */
+  action: LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED;
+  fieldId: string;
+  entryId: string;
+  locale: string;
+};
+
+/** @deprecated use RequestEntitiesMessage instead */
+export type UnknownEntityMessage = {
+  /** @deprecated use method instead */
+  action: LivePreviewPostMessageMethods.ENTITY_NOT_KNOWN;
+  referenceEntityId: string;
+  referenceContentType?: string;
+};
+
+export type UrlChangedMessage = {
+  /** @deprecated use method instead */
+  action: LivePreviewPostMessageMethods.URL_CHANGED;
+};
+
+export type SubscribedMessage = {
+  /** @deprecated use method instead */
+  action: LivePreviewPostMessageMethods.SUBSCRIBED;
+  type: 'GQL' | 'REST';
+  locale: string;
+};
+
+export type EditorMessage =
+  | ConnectedMessage
+  | TaggedFieldClickMessage
+  | UnknownEntityMessage
+  | UrlChangedMessage
+  | SubscribedMessage
+  | RequestEntitiesMessage;
+
+export type MessageFromSDK = EditorMessage & {
+  method: PostMessageMethods;
+  /** @deprecated use source instead */
+  from: 'live-preview';
+  source: typeof LIVE_PREVIEW_SDK_SOURCE;
+  location: string;
+  version: string;
+};
+
+export type EntryUpdatedMessage = {
+  /** @deprecated use method instead */
+  action: LivePreviewPostMessageMethods.ENTRY_UPDATED;
+  method: LivePreviewPostMessageMethods.ENTRY_UPDATED;
+  entity: EntryProps | AssetProps;
+  contentType: ContentType;
+  entityReferenceMap: EntityReferenceMap;
+};
+
+export type EntrySavedMessage = {
+  method: LivePreviewPostMessageMethods.ENTRY_SAVED;
+  entity: EntryProps | AssetProps;
+  contentType: ContentType;
+  entityReferenceMap: EntityReferenceMap;
+};
+
+/** @deprecated use RequestEntitiesMessage instead */
+export type UnknownReferenceLoaded = {
+  /** @deprecated use method instead */
+  action: LivePreviewPostMessageMethods.UNKNOWN_REFERENCE_LOADED;
+  reference: EntryProps | AssetProps;
+  contentType?: SysLink;
+  entityReferenceMap: EntityReferenceMap;
+};
+
+export type InspectorModeChangedMessage = {
+  /** @deprecated use method instead */
+  action: LivePreviewPostMessageMethods.INSPECTOR_MODE_CHANGED;
+  isInspectorActive: boolean;
+};
+
+export type DebugModeEnabledMessage = {
+  /** @deprecated use method instead */
+  action: LivePreviewPostMessageMethods.DEBUG_MODE_ENABLED;
+};
+
+export type MessageFromEditor = (
+  | EntryUpdatedMessage
+  | EntrySavedMessage
+  | UnknownReferenceLoaded
+  | InspectorModeChangedMessage
+  | DebugModeEnabledMessage
+  | RequestedEntitiesMessage
+) & {
+  method: PostMessageMethods;
+  /** @deprecated use source instead */
+  from: 'live-preview';
+  source: typeof LIVE_PREVIEW_EDITOR_SOURCE;
+};

--- a/packages/live-preview-sdk/src/types.ts
+++ b/packages/live-preview-sdk/src/types.ts
@@ -1,6 +1,4 @@
-import type { RequestEntitiesMessage, RequestedEntitiesMessage } from '@contentful/visual-sdk';
-import { PostMessageMethods as StorePostMessageMethods } from '@contentful/visual-sdk';
-import type { AssetProps, EntryProps, ContentTypeProps, SysLink } from 'contentful-management';
+import type { AssetProps, EntryProps, ContentTypeProps } from 'contentful-management';
 
 export type ContentType = ContentTypeProps;
 export const ASSET_TYPENAME = 'Asset';
@@ -50,129 +48,12 @@ export function hasSysInformation(entity: unknown): entity is EntityWithSys {
 export type Argument = Entity | Entity[];
 export type SubscribeCallback = (data: Argument) => void;
 
-export enum LivePreviewPostMessageMethods {
-  IFRAME_CONNECTED = 'IFRAME_CONNECTED',
-  TAGGED_FIELD_CLICKED = 'TAGGED_FIELD_CLICKED',
-  URL_CHANGED = 'URL_CHANGED',
-  SUBSCRIBED = 'SUBSCRIBED',
-
-  ENTRY_UPDATED = 'ENTRY_UPDATED',
-  INSPECTOR_MODE_CHANGED = 'INSPECTOR_MODE_CHANGED',
-  DEBUG_MODE_ENABLED = 'DEBUG_MODE_ENABLED',
-
-  /**
-   * @deprecated use PostMessageStoreMethods instead
-   */
-  ENTITY_NOT_KNOWN = 'ENTITY_NOT_KNOWN',
-  /**
-   * @deprecated use PostMessageStoreMethods instead
-   */
-  UNKNOWN_REFERENCE_LOADED = 'UNKNOWN_REFERENCE_LOADED',
-}
-
-export type PostMessageMethods = LivePreviewPostMessageMethods | StorePostMessageMethods;
-
 export interface CollectionItem {
   sys: SysProps;
   __typename?: string;
 }
 
-export type IframeConnectedMessage = {
-  /** @deprecated use method instead */
-  action: LivePreviewPostMessageMethods.IFRAME_CONNECTED;
-  connected: true;
-  tags: number;
-  locale: string;
-};
-
-export type TaggedFieldClickMessage = {
-  /** @deprecated use method instead */
-  action: LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED;
-  fieldId: string;
-  entryId: string;
-  locale: string;
-};
-
-/** @deprecated use RequestEntitiesMessage instead */
-export type UnknownEntityMessage = {
-  /** @deprecated use method instead */
-  action: LivePreviewPostMessageMethods.ENTITY_NOT_KNOWN;
-  referenceEntityId: string;
-  referenceContentType?: string;
-};
-
-export type UrlChangedMessage = {
-  /** @deprecated use method instead */
-  action: LivePreviewPostMessageMethods.URL_CHANGED;
-};
-
-export type SubscribedMessage = {
-  /** @deprecated use method instead */
-  action: LivePreviewPostMessageMethods.SUBSCRIBED;
-  type: 'GQL' | 'REST';
-  locale: string;
-};
-
 export class EntityReferenceMap extends Map<string, EntryProps | AssetProps> {}
-
-export type EditorMessage =
-  | IframeConnectedMessage
-  | TaggedFieldClickMessage
-  | UnknownEntityMessage
-  | UrlChangedMessage
-  | SubscribedMessage
-  | RequestEntitiesMessage;
-
-export type MessageFromSDK = EditorMessage & {
-  method: PostMessageMethods;
-  /** @deprecated use source instead */
-  from: 'live-preview';
-  source: 'live-preview-sdk';
-  location: string;
-  version: string;
-};
-
-export type EntryUpdatedMessage = {
-  /** @deprecated use method instead */
-  action: LivePreviewPostMessageMethods.ENTRY_UPDATED;
-  method: LivePreviewPostMessageMethods.ENTRY_UPDATED;
-  entity: EntryProps | AssetProps;
-  contentType: ContentType;
-  entityReferenceMap: EntityReferenceMap;
-};
-
-/** @deprecated use RequestEntitiesMessage instead */
-export type UnknownReferenceLoaded = {
-  /** @deprecated use method instead */
-  action: LivePreviewPostMessageMethods.UNKNOWN_REFERENCE_LOADED;
-  reference: EntryProps | AssetProps;
-  contentType?: SysLink;
-  entityReferenceMap: EntityReferenceMap;
-};
-
-export type InspectorModeChanged = {
-  /** @deprecated use method instead */
-  action: LivePreviewPostMessageMethods.INSPECTOR_MODE_CHANGED;
-  isInspectorActive: boolean;
-};
-
-export type DebugModeEnabled = {
-  /** @deprecated use method instead */
-  action: LivePreviewPostMessageMethods.DEBUG_MODE_ENABLED;
-};
-
-export type MessageFromEditor = (
-  | EntryUpdatedMessage
-  | UnknownReferenceLoaded
-  | InspectorModeChanged
-  | DebugModeEnabled
-  | RequestedEntitiesMessage
-) & {
-  method: PostMessageMethods;
-  /** @deprecated use source instead */
-  from: 'live-preview';
-  source: 'live-preview-app';
-};
 
 export type UpdateEntryProps = {
   contentType: ContentType;

--- a/packages/visual-sdk/src/index.ts
+++ b/packages/visual-sdk/src/index.ts
@@ -1,1 +1,1 @@
-export * from './store';
+export * from './store/index';


### PR DESCRIPTION
Extract the enum for the Post Messages and the correlated message types from './types' as a `enum` is technically more than a type and to be able to easily share them
Optimizes also the exports so you don't need to import from 'dist/types' anymore