### PR TITLE
fix: fix react server component provider issues by adding 'use client'

### DIFF
--- a/packages/live-preview-sdk/src/react.tsx
+++ b/packages/live-preview-sdk/src/react.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   createContext,
   useCallback,


### PR DESCRIPTION
I am trying to import and use this package in a project using the next 13 app directory, but am having issues with the `ContentfulLivePreviewProvider` not using the new `'use client'` directive. 

I can workaround this issue by creating a new file, like so:
```tsx
'use client';

export { ContentfulLivePreviewProvider } from '@contentful/live-preview/react';
```
Then importing the provider from this file - but would rather not have to do this to use this package.

Seeing as React Server Components are the new narrative being pushed by React / Next.js is there any chance we can merge this PR so others do not need to use this workaround?

- https://vercel.com/guides/react-context-state-management-nextjs#rendering-third-party-context-providers-in-server-components