### PR TITLE
fix(live-preview): adjust missing data for the status modal

### DIFF
--- a/packages/live-preview-sdk/src/index.ts
+++ b/packages/live-preview-sdk/src/index.ts
@@ -126,17 +126,20 @@ export class ContentfulLivePreview {
       pollUrlChanges(() => {
         sendMessageToEditor(LivePreviewPostMessageMethods.URL_CHANGED, {
           action: LivePreviewPostMessageMethods.URL_CHANGED,
-          taggedElementCount: this.inspectorMode?.getTaggedElements().length,
+          taggedElementCount: document.querySelectorAll(`[${TagAttributes.ENTRY_ID}]`).length,
         } as UrlChangedMessage);
       });
 
       // tell the editor that there's a SDK
+      const taggedElementCount = document.querySelectorAll(`[${TagAttributes.ENTRY_ID}]`).length;
       sendMessageToEditor(LivePreviewPostMessageMethods.CONNECTED, {
         action: LivePreviewPostMessageMethods.CONNECTED,
         connected: true,
-        tags: this.inspectorMode?.getTaggedElements().length,
-        taggedElementCount: this.inspectorMode?.getTaggedElements().length,
+        tags: taggedElementCount,
+        taggedElementCount,
         locale: this.locale,
+        isInspectorEnabled: this.inspectorModeEnabled,
+        isLiveUpdatesEnabled: this.liveUpdatesEnabled,
       } as ConnectedMessage);
 
       // all set up - ready to go

--- a/packages/live-preview-sdk/src/inspectorMode.ts
+++ b/packages/live-preview-sdk/src/inspectorMode.ts
@@ -34,10 +34,6 @@ export class InspectorMode {
     window.addEventListener('mouseover', this.addTooltipOnHover);
   }
 
-  public getTaggedElements() {
-    return document.querySelectorAll(`[${TagAttributes.ENTRY_ID}]`);
-  }
-
   // Handles incoming messages from Contentful
   public receiveMessage(data: MessageFromEditor): void {
     if (

--- a/packages/live-preview-sdk/src/messages.ts
+++ b/packages/live-preview-sdk/src/messages.ts
@@ -49,6 +49,8 @@ export type ConnectedMessage = {
   /** @deprecated use taggedElementCount instead */
   tags: number;
   taggedElementCount: number;
+  isInspectorEnabled: boolean;
+  isLiveUpdatesEnabled: boolean;
 };
 
 export type TaggedFieldClickMessage = {


### PR DESCRIPTION
`this.inspectorMode?.getTaggedElements()` as the inspectorMode could be undefined, we don't always send the tagged elements and therefore the analytics for the statusmodal can be faulty.