### PR TITLE
feat: expose opening entry [TOL-1237]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Live preview SDK for both the inspector mode connection + live content updates b
 <summary>Table of contents</summary>
 
 <!-- TOC -->
+
 - [Getting started](#getting-started)
   - [Requirements](#requirements)
   - [Installation](#installation)
@@ -151,6 +152,26 @@ const query = gql`
 // ...
 const updated = useContentfulLiveUpdates(originalData, { query });
 // ...
+```
+
+### Open Entry in Editor
+
+`ContentfulLivePreview.openEntryInEditor({fieldId: string, entryId: string, locale: string})`
+
+Opens an entry in the Contentful live preview editor. This utility function allows for manual control over the editor opening process, providing flexibility for developers to integrate this action within custom UI components or events.
+
+- **fieldId** (string): The ID of the field you want to target.
+- **entryId** (string): The ID of the entry containing the field.
+- **locale** (string): The locale of the content.
+
+**Usage**:
+
+```javascript
+ContentfulLivePreview.openEntryInEditor({
+  entryId: 'entryId',
+  fieldId: 'fieldId',
+  locale: 'en-US',
+});
 ```
 
 ## Example Integrations

--- a/packages/live-preview-sdk/src/index.ts
+++ b/packages/live-preview-sdk/src/index.ts
@@ -17,6 +17,7 @@ import {
   LivePreviewPostMessageMethods,
   MessageFromEditor,
   UrlChangedMessage,
+  openEntryInEditorUtility,
 } from './messages';
 import {
   Argument,
@@ -191,6 +192,14 @@ export class ContentfulLivePreview {
   static toggleLiveUpdatesMode(): boolean {
     this.liveUpdatesEnabled = !this.liveUpdatesEnabled;
     return this.liveUpdatesEnabled;
+  }
+
+  static openEntryInEditor({ fieldId, entryId, locale }: LivePreviewProps): void {
+    if (!fieldId || !entryId) {
+      debug.error('Please provide field id and entry id to openEntryInEditor.');
+    }
+
+    openEntryInEditorUtility(fieldId, entryId, locale || this.locale);
   }
 }
 

--- a/packages/live-preview-sdk/src/inspectorMode.ts
+++ b/packages/live-preview-sdk/src/inspectorMode.ts
@@ -6,11 +6,11 @@ import {
   TOOLTIP_HEIGHT,
   TOOLTIP_PADDING_LEFT,
 } from './constants';
-import { sendMessageToEditor } from './helpers';
 import {
   InspectorModeChangedMessage,
   LivePreviewPostMessageMethods,
   MessageFromEditor,
+  openEntryInEditorUtility,
 } from './messages';
 import { TagAttributes } from './types';
 
@@ -115,20 +115,12 @@ export class InspectorMode {
 
   // responsible for handling the event when the user clicks on the edit button in the tooltip
   private clickHandler() {
-    if (!this.tooltip) {
-      return;
-    }
-    const fieldId = this.tooltip.getAttribute(DATA_CURR_FIELD_ID);
-    const entryId = this.tooltip.getAttribute(DATA_CURR_ENTRY_ID);
-    const locale = this.tooltip.getAttribute(DATA_CURR_LOCALE);
+    const fieldId = this.tooltip?.getAttribute(DATA_CURR_FIELD_ID);
+    const entryId = this.tooltip?.getAttribute(DATA_CURR_ENTRY_ID);
+    const locale = this.tooltip?.getAttribute(DATA_CURR_LOCALE) || this.defaultLocale;
 
     if (fieldId && entryId && locale) {
-      sendMessageToEditor(LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED, {
-        action: LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED,
-        fieldId,
-        entryId,
-        locale,
-      });
+      openEntryInEditorUtility(fieldId, entryId, locale);
     }
   }
 }

--- a/packages/live-preview-sdk/src/messages.ts
+++ b/packages/live-preview-sdk/src/messages.ts
@@ -4,6 +4,7 @@ import type { Asset, Entry } from 'contentful';
 import type { SysLink } from 'contentful-management';
 
 import type { LIVE_PREVIEW_EDITOR_SOURCE, LIVE_PREVIEW_SDK_SOURCE } from './constants';
+import { sendMessageToEditor } from './helpers';
 import type { ContentType, EntityReferenceMap } from './types';
 
 enum LivePreviewPostMessageMethods {
@@ -159,3 +160,12 @@ export type MessageFromEditor = (
   from: 'live-preview';
   source: typeof LIVE_PREVIEW_EDITOR_SOURCE;
 };
+
+export function openEntryInEditorUtility(fieldId: string, entryId: string, locale: string): void {
+  sendMessageToEditor(LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED, {
+    action: LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED,
+    fieldId,
+    entryId,
+    locale,
+  });
+}


### PR DESCRIPTION
Exposing and decoupling the logic for opening an entry in the Contentful UI from the specific inspector mode class