### PR TITLE
fix(graphql): providing the query no longer prevents updates [TOL-1409]

### DIFF
--- a/examples/nextjs-graphql/package.json
+++ b/examples/nextjs-graphql/package.json
@@ -6,10 +6,11 @@
     "start": "next start"
   },
   "dependencies": {
-    "@contentful/live-preview": "^2.4.3",
+    "@contentful/live-preview": "latest",
     "@types/node": "20.2.3",
     "@types/react": "18.2.7",
     "@types/react-dom": "18.2.4",
+    "graphql-request": "6.1.0",
     "next": "13.4.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/examples/nextjs-graphql/pages/_app.tsx
+++ b/examples/nextjs-graphql/pages/_app.tsx
@@ -8,6 +8,7 @@ function App({ Component, pageProps }: AppProps) {
       locale="en-US"
       enableInspectorMode={pageProps.draftMode}
       enableLiveUpdates={pageProps.draftMode}
+      debugMode
     >
       <Component {...pageProps} />
     </ContentfulLivePreviewProvider>

--- a/examples/nextjs-graphql/pages/posts/[slug].tsx
+++ b/examples/nextjs-graphql/pages/posts/[slug].tsx
@@ -6,7 +6,12 @@ import {
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import ErrorPage from 'next/error';
-import { Post as PostType, getAllPostsWithSlug, getPost } from '../../lib/api-graphql';
+import {
+  ALL_POSTS_SLUGGED_QUERY,
+  Post as PostType,
+  getAllPostsWithSlug,
+  getPost,
+} from '../../lib/api-graphql';
 
 interface PostProps {
   post: PostType | null;
@@ -14,7 +19,9 @@ interface PostProps {
 
 const Post: NextPage<PostProps> = ({ post }) => {
   const router = useRouter();
-  const updatedPost = useContentfulLiveUpdates(post);
+  const updatedPost = useContentfulLiveUpdates(post, {
+    query: ALL_POSTS_SLUGGED_QUERY,
+  });
   const inspectorProps = useContentfulInspectorMode({ entryId: post?.sys.id });
 
   if (!router.isFallback && !updatedPost) {

--- a/packages/live-preview-sdk/src/graphql/__tests__/queryUtils.test.ts
+++ b/packages/live-preview-sdk/src/graphql/__tests__/queryUtils.test.ts
@@ -16,6 +16,7 @@ const query = gql`
       }
       topSectionCollection {
         items {
+          __typename
           sys {
             id
           }
@@ -48,7 +49,7 @@ describe('parseGraphQLParams', () => {
         ['sys', { alias: new Map(), fields: new Set(['id']) }],
         ['content', { alias: new Map(), fields: new Set(['json']) }],
         ['topSectionCollection', { alias: new Map(), fields: new Set(['items']) }],
-        ['items', { alias: new Map(), fields: new Set(['sys']) }],
+        ['TopSection', { alias: new Map(), fields: new Set(['sys', '__typename']) }],
       ])
     );
   });

--- a/packages/live-preview-sdk/src/graphql/entries.ts
+++ b/packages/live-preview-sdk/src/graphql/entries.ts
@@ -2,14 +2,7 @@ import { BLOCKS, INLINES } from '@contentful/rich-text-types';
 import { Asset, Entry } from 'contentful';
 import type { SetOptional } from 'type-fest';
 
-import {
-  isPrimitiveField,
-  updatePrimitiveField,
-  resolveReference,
-  clone,
-  debug,
-  generateTypeName,
-} from '../helpers';
+import { isPrimitiveField, updatePrimitiveField, resolveReference, clone, debug } from '../helpers';
 import { SUPPORTED_RICHTEXT_EMBEDS, isAsset, isRichText } from '../helpers/entities';
 import {
   CollectionItem,
@@ -24,7 +17,7 @@ import {
 } from '../types';
 import { updateAsset } from './assets';
 import { isRelevantField, updateAliasedInformation } from './queryUtils';
-import { buildCollectionName } from './utils';
+import { buildCollectionName, generateTypeName } from './utils';
 
 /**
  * Updates GraphQL response data based on CMA entry object

--- a/packages/live-preview-sdk/src/graphql/utils.ts
+++ b/packages/live-preview-sdk/src/graphql/utils.ts
@@ -1,6 +1,22 @@
 const COLLECTION_SUFFIX = 'Collection';
 
+export function generateTypeName(contentTypeId: string): string {
+  return contentTypeId.charAt(0).toUpperCase() + contentTypeId.slice(1);
+}
+
 /** Generates the name of the field for a collection */
 export function buildCollectionName(name: string): string {
   return `${name}${COLLECTION_SUFFIX}`;
+}
+
+/**
+ * Extract the name of an entry from the collection (e.g. "postCollection" => "Post")
+ * Returns undefined if the name doesn't has the collection suffix.
+ */
+export function extractNameFromCollectionName(collection: string): string | undefined {
+  if (!collection.endsWith(COLLECTION_SUFFIX)) {
+    return undefined;
+  }
+
+  return generateTypeName(collection.replace(COLLECTION_SUFFIX, ''));
 }

--- a/packages/live-preview-sdk/src/helpers/resolveReference.ts
+++ b/packages/live-preview-sdk/src/helpers/resolveReference.ts
@@ -3,12 +3,9 @@ import type { Asset, Entry } from 'contentful';
 
 import { ASSET_TYPENAME, EntityReferenceMap } from '../types';
 import { sendMessageToEditor } from './utils';
+import { generateTypeName } from '../graphql/utils';
 
 const store: Record<string, EditorEntityStore> = {};
-
-export function generateTypeName(contentTypeId: string): string {
-  return contentTypeId.charAt(0).toUpperCase() + contentTypeId.slice(1);
-}
 
 function getStore(locale: string): EditorEntityStore {
   if (!store[locale]) {


### PR DESCRIPTION
The typename for fields inside a collection was not correctly generated, and therefore they were not identified correctly and in `isRelevantField` they were ignored.
We now generate the typename correctly instead of  `items`, which enables updates again.

Migrated the nextjs-graphql example to use graphql-request and GraphQL Documents, which allows us to also demo the usage with a provided query