### PR TITLE
fix(example): next 13 with app router

### DIFF
--- a/examples/next-13-app-router-graphql/app/layout.tsx
+++ b/examples/next-13-app-router-graphql/app/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { draftMode } from 'next/headers';
-import './globals.css';
 import { Providers } from './providers';
+import '@contentful/live-preview/style.css';
 
 const inter = Inter({ subsets: ['latin'] });
 

--- a/examples/next-13-app-router-graphql/package.json
+++ b/examples/next-13-app-router-graphql/package.json
@@ -6,12 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "prepare": "relative-deps"
+    "lint": "next lint"
   },
   "dependencies": {
-    "@contentful/live-preview": "^2.4.6",
-    "@contentful/visual-sdk": "^1.0.0-alpha.11",
+    "@contentful/live-preview": "^2.9.5",
     "@types/node": "20.5.0",
     "@types/react": "18.2.20",
     "@types/react-dom": "18.2.7",


### PR DESCRIPTION
Hi there,

I am currently setting up the live preview mode for Contentful. The `live-updates` are working, but the inspector mode was missing the css import in the next 13 example app:
https://github.com/contentful/live-preview/tree/main/examples/next-13-app-router-graphql

I have also deleted the `globals.css` and the `prepare` step in the package.json, since they where both unused and preventing the app from starting.

:v: 

