### PR TITLE
fix: allow overriding the targetOrigin for messaging []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - checkout
       - yarn_install
       - run: yarn lint
+      - run: yarn tsc
       - run: yarn build
   unit-tests:
     executor: linux-node

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 .rts2_cache_esm
 .rts2_cache_umd
 package-lock.json
+examples/**/yarn.lock
 /mochawesome-report
 build/
 dist/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ ContentfulLivePreview.init({
   enableInspectorMode: false, // This allows you to toggle the inspector mode which is on by default
   enableLiveUpdates: false, // This allows you to toggle the live updates which is on by default
   debugMode: false, // This allows you to toggle the debug mode which is off by default
+  targetOrigin: 'https://app.contentful.com', // This allows you to configure the allowed host of the live preview (default: ['https://app.contentful.com', 'https://app.eu.contentful.com'])
 });
 ```
 

--- a/examples/next-13-app-router-ssr/README.md
+++ b/examples/next-13-app-router-ssr/README.md
@@ -1,6 +1,10 @@
 # Next.js GraphQL Contentful live preview SDK example
 
-This is an example project that demonstrates how to use the `@contentful/live-preview` SDK with a Next.js application that uses the GraphQL API. The live preview SDK will reload the page after **related** content changes and enables the inspector mode for your Contentful space.
+This is an example project that demonstrates how to use the `@contentful/live-preview` SDK with a Next.js application that runs only on the server.
+
+The live preview SDK will be in an seperate [script](./public/_live-preview.ts), reload the page after **related** content changes and enables the inspector mode for your application.
+
+
 It's important that you use the CPA (Content Preview API) when using this functionality.
 
 ## 1. Installation

--- a/examples/next-13-app-router-ssr/package.json
+++ b/examples/next-13-app-router-ssr/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
+    "dev": "npm run build:script && npm run dev:next",
+    "dev:next": "next dev",
+    "build": "npm run build:script && npm run build:next",
     "build:next": "next build",
     "build:script": "vite build",
     "start": "next start",
@@ -13,7 +14,6 @@
   },
   "dependencies": {
     "@contentful/live-preview": "../../packages/live-preview-sdk",
-    "@contentful/visual-sdk": "^1.0.0-alpha.11",
     "next": "13.4.13",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/packages/live-preview-sdk/src/__tests__/inspectorMode.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/inspectorMode.spec.ts
@@ -9,9 +9,10 @@ const locale = 'en-US';
 
 describe('InspectorMode', () => {
   let inspectorMode: InspectorMode;
+  const targetOrigin = ['https://app.contentful.com'];
 
   beforeEach(() => {
-    inspectorMode = new InspectorMode({ locale });
+    inspectorMode = new InspectorMode({ locale, targetOrigin });
   });
 
   afterEach(() => {

--- a/packages/live-preview-sdk/src/__tests__/react.spec.tsx
+++ b/packages/live-preview-sdk/src/__tests__/react.spec.tsx
@@ -64,7 +64,7 @@ describe('useContentfulLiveUpdates', () => {
     });
 
     expect(subscribe).toHaveBeenCalledTimes(1);
-    expect(subscribe).toHaveBeenCalledWith({
+    expect(subscribe).toHaveBeenCalledWith('edit', {
       data: initialData,
       locale,
       callback: expect.any(Function),
@@ -108,7 +108,7 @@ describe('useContentfulLiveUpdates', () => {
 
     const updatedData1 = createData('4', 'Hello World');
     act(() => {
-      subscribe.mock.calls[0][0].callback(updatedData1);
+      subscribe.mock.calls[0][1].callback(updatedData1);
       vi.advanceTimersToNextTimer();
     });
 
@@ -116,7 +116,7 @@ describe('useContentfulLiveUpdates', () => {
 
     const updatedData2 = createData('4', 'Hello World!');
     act(() => {
-      subscribe.mock.calls[0][0].callback(updatedData2);
+      subscribe.mock.calls[0][1].callback(updatedData2);
       vi.advanceTimersToNextTimer();
     });
 
@@ -142,11 +142,11 @@ describe('useContentfulLiveUpdates', () => {
 
     const updatedData = createData('5', 'Hello World');
     act(() => {
-      subscribe.mock.calls[0][0].callback(createData('5', 'Hello W'));
-      subscribe.mock.calls[0][0].callback(createData('5', 'Hello Wo'));
-      subscribe.mock.calls[0][0].callback(createData('5', 'Hello Wor'));
-      subscribe.mock.calls[0][0].callback(createData('5', 'Hello Worl'));
-      subscribe.mock.calls[0][0].callback(updatedData);
+      subscribe.mock.calls[0][1].callback(createData('5', 'Hello W'));
+      subscribe.mock.calls[0][1].callback(createData('5', 'Hello Wo'));
+      subscribe.mock.calls[0][1].callback(createData('5', 'Hello Wor'));
+      subscribe.mock.calls[0][1].callback(createData('5', 'Hello Worl'));
+      subscribe.mock.calls[0][1].callback(updatedData);
       vi.advanceTimersToNextTimer();
     });
 

--- a/packages/live-preview-sdk/src/__tests__/resolveReference.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/resolveReference.spec.ts
@@ -11,6 +11,7 @@ vi.mock('@contentful/visual-sdk');
 
 describe('resolveReference', () => {
   const locale = 'en-US';
+  const sendMessage = vi.fn();
 
   beforeEach(() => {
     (EditorEntityStore as Mock).mockImplementation(() => ({
@@ -51,6 +52,7 @@ describe('resolveReference', () => {
         entityReferenceMap: new Map([['1', asset]]),
         referenceId: '1',
         locale,
+        sendMessage,
       });
 
       expect(result).toEqual(expected);
@@ -62,6 +64,7 @@ describe('resolveReference', () => {
         referenceId: cdaAsset.sys.id,
         isAsset: true,
         locale,
+        sendMessage,
       });
 
       expect(result.typeName).toBe('Asset');
@@ -102,6 +105,7 @@ describe('resolveReference', () => {
         entityReferenceMap: new Map([['1', entry]]),
         referenceId: '1',
         locale,
+        sendMessage,
       });
 
       expect(result).toEqual(expected);
@@ -112,6 +116,7 @@ describe('resolveReference', () => {
         entityReferenceMap: new Map(),
         referenceId: cdaEntry.sys.id,
         locale,
+        sendMessage,
       });
 
       expect(result.typeName).toBe('TopicProductFeature');

--- a/packages/live-preview-sdk/src/constants.ts
+++ b/packages/live-preview-sdk/src/constants.ts
@@ -12,5 +12,3 @@ export const MAX_DEPTH = 10;
 
 export const LIVE_PREVIEW_EDITOR_SOURCE = 'live-preview-editor' as const;
 export const LIVE_PREVIEW_SDK_SOURCE = 'live-preview-sdk' as const;
-
-export const CONTENTFUL_ORIGINS = ['https://app.contentful.com', 'https://app.eu.contentful.com'];

--- a/packages/live-preview-sdk/src/graphql/__tests__/entries.test.ts
+++ b/packages/live-preview-sdk/src/graphql/__tests__/entries.test.ts
@@ -19,6 +19,7 @@ const defaultContentType = defaultContentTypeJSON as ContentTypeProps;
 // Note: we can get rid of expect.objectContaining, if we iterate over the provided data instead of the ContentType.fields
 describe('Update GraphQL Entry', () => {
   const testReferenceId = '18kDTlnJNnDIJf6PsXE5Mr';
+  const sendMessage = vi.fn();
 
   beforeEach(() => {
     (resolveReference as Mock).mockResolvedValue({
@@ -59,6 +60,7 @@ describe('Update GraphQL Entry', () => {
       updateFromEntryEditor: update,
       locale,
       entityReferenceMap,
+      sendMessage,
     });
   };
 

--- a/packages/live-preview-sdk/src/helpers/resolveReference.ts
+++ b/packages/live-preview-sdk/src/helpers/resolveReference.ts
@@ -1,4 +1,9 @@
-import { EditorEntityStore, RequestedEntitiesMessage } from '@contentful/visual-sdk';
+import {
+  EditorEntityStore,
+  PostMessageMethods,
+  RequestEntitiesMessage,
+  RequestedEntitiesMessage,
+} from '@contentful/visual-sdk';
 import type { Asset, Entry } from 'contentful';
 
 import { generateTypeName } from '../graphql/utils';
@@ -6,10 +11,9 @@ import { ASSET_TYPENAME, EntityReferenceMap } from '../types';
 
 const store: Record<string, EditorEntityStore> = {};
 
-function getStore(
-  locale: string,
-  sendMessage: EditorEntityStore['sendMessage']
-): EditorEntityStore {
+export type SendMessage = (method: PostMessageMethods, params: RequestEntitiesMessage) => void;
+
+function getStore(locale: string, sendMessage: SendMessage): EditorEntityStore {
   if (!store[locale]) {
     store[locale] = new EditorEntityStore({
       entities: [],
@@ -41,12 +45,14 @@ export async function resolveReference(info: {
   entityReferenceMap: EntityReferenceMap;
   referenceId: string;
   locale: string;
+  sendMessage: SendMessage;
 }): Promise<{ reference: Entry; typeName: string }>;
 export async function resolveReference(info: {
   entityReferenceMap: EntityReferenceMap;
   referenceId: string;
   isAsset: true;
   locale: string;
+  sendMessage: SendMessage;
 }): Promise<{ reference: Asset; typeName: string }>;
 /**
  * Returns the requested reference from
@@ -64,7 +70,7 @@ export async function resolveReference({
   referenceId: string;
   isAsset?: boolean;
   locale: string;
-  sendMessage: EditorEntityStore['sendMessage'];
+  sendMessage: SendMessage;
 }): Promise<{ reference: Entry | Asset; typeName: string }> {
   const reference = entityReferenceMap.get(referenceId);
 

--- a/packages/live-preview-sdk/src/helpers/utils.ts
+++ b/packages/live-preview-sdk/src/helpers/utils.ts
@@ -1,5 +1,5 @@
 import { version } from '../../package.json';
-import { CONTENTFUL_ORIGINS, LIVE_PREVIEW_SDK_SOURCE } from '../constants';
+import { LIVE_PREVIEW_SDK_SOURCE } from '../constants';
 import { PostMessageMethods } from '../messages';
 import type { EditorMessage, MessageFromSDK } from '../messages';
 import { debug } from './debug';
@@ -8,7 +8,11 @@ import { debug } from './debug';
  * Sends the given message to the editor
  * enhances it with the information necessary to be accepted
  */
-export function sendMessageToEditor(method: PostMessageMethods, data: EditorMessage): void {
+export function sendMessageToEditor(
+  method: PostMessageMethods,
+  data: EditorMessage,
+  targetOrigin: string[]
+): void {
   const message: MessageFromSDK = {
     ...data,
     method,
@@ -20,7 +24,7 @@ export function sendMessageToEditor(method: PostMessageMethods, data: EditorMess
 
   debug.log('Send message', message);
 
-  CONTENTFUL_ORIGINS.forEach((origin) => {
+  targetOrigin.forEach((origin) => {
     window.top?.postMessage(message, origin);
   });
 }

--- a/packages/live-preview-sdk/src/index.ts
+++ b/packages/live-preview-sdk/src/index.ts
@@ -16,8 +16,10 @@ import { InspectorMode } from './inspectorMode';
 import { LiveUpdates } from './liveUpdates';
 import {
   ConnectedMessage,
+  EditorMessage,
   LivePreviewPostMessageMethods,
   MessageFromEditor,
+  PostMessageMethods,
   UrlChangedMessage,
   openEntryInEditorUtility,
 } from './messages';
@@ -61,6 +63,7 @@ export class ContentfulLivePreview {
   static inspectorModeEnabled = true;
   static liveUpdatesEnabled = true;
   static locale: string;
+  static sendMessage: (method: PostMessageMethods, data: EditorMessage) => void;
   static targetOrigin: string[];
 
   // Static method to initialize the LivePreview SDK
@@ -113,11 +116,11 @@ export class ContentfulLivePreview {
 
       // setup the live preview plugins (inspectorMode and liveUpdates)
       if (this.inspectorModeEnabled) {
-        this.inspectorMode = new InspectorMode({ locale });
+        this.inspectorMode = new InspectorMode({ locale, targetOrigin: this.targetOrigin });
       }
 
       if (this.liveUpdatesEnabled) {
-        this.liveUpdates = new LiveUpdates({ locale, origins: this.targetOrigin });
+        this.liveUpdates = new LiveUpdates({ locale, targetOrigin: this.targetOrigin });
         this.saveEvent = new SaveEvent({ locale });
       }
 

--- a/packages/live-preview-sdk/src/inspectorMode.ts
+++ b/packages/live-preview-sdk/src/inspectorMode.ts
@@ -18,11 +18,13 @@ export class InspectorMode {
   private tooltip: HTMLButtonElement | null = null; // this tooltip scrolls to the correct field in the entry editor
   private currentElementBesideTooltip: HTMLElement | null = null; // this element helps to position the tooltip
   private defaultLocale: string;
+  private targetOrigin: string[];
 
-  constructor({ locale }: { locale: string }) {
+  constructor({ locale, targetOrigin }: { locale: string; targetOrigin: string[] }) {
     this.tooltip = null;
     this.currentElementBesideTooltip = null;
     this.defaultLocale = locale;
+    this.targetOrigin = targetOrigin;
 
     this.updateTooltipPosition = this.updateTooltipPosition.bind(this);
     this.addTooltipOnHover = this.addTooltipOnHover.bind(this);
@@ -120,7 +122,7 @@ export class InspectorMode {
     const locale = this.tooltip?.getAttribute(DATA_CURR_LOCALE) || this.defaultLocale;
 
     if (fieldId && entryId && locale) {
-      openEntryInEditorUtility(fieldId, entryId, locale);
+      openEntryInEditorUtility(fieldId, entryId, locale, this.targetOrigin);
     }
   }
 }

--- a/packages/live-preview-sdk/src/messages.ts
+++ b/packages/live-preview-sdk/src/messages.ts
@@ -162,11 +162,20 @@ export type MessageFromEditor = (
   source: typeof LIVE_PREVIEW_EDITOR_SOURCE;
 };
 
-export function openEntryInEditorUtility(fieldId: string, entryId: string, locale: string): void {
-  sendMessageToEditor(LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED, {
-    action: LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED,
-    fieldId,
-    entryId,
-    locale,
-  });
+export function openEntryInEditorUtility(
+  fieldId: string,
+  entryId: string,
+  locale: string,
+  targetOrigin: string[]
+): void {
+  sendMessageToEditor(
+    LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED,
+    {
+      action: LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED,
+      fieldId,
+      entryId,
+      locale,
+    },
+    targetOrigin
+  );
 }

--- a/packages/live-preview-sdk/src/react.tsx
+++ b/packages/live-preview-sdk/src/react.tsx
@@ -55,6 +55,7 @@ export function ContentfulLivePreviewProvider({
   debugMode = false,
   enableInspectorMode = true,
   enableLiveUpdates = true,
+  targetOrigin,
 }: PropsWithChildren<ContentfulLivePreviewInitConfig>): ReactElement {
   if (!locale) {
     throw new Error(
@@ -62,11 +63,17 @@ export function ContentfulLivePreviewProvider({
     );
   }
 
-  ContentfulLivePreview.init({ locale, debugMode, enableInspectorMode, enableLiveUpdates });
+  ContentfulLivePreview.init({
+    locale,
+    debugMode,
+    enableInspectorMode,
+    enableLiveUpdates,
+    targetOrigin,
+  });
 
   const props = useMemo(
-    () => ({ locale, debugMode, enableInspectorMode, enableLiveUpdates }),
-    [locale, debugMode, enableInspectorMode, enableLiveUpdates]
+    () => ({ locale, debugMode, enableInspectorMode, enableLiveUpdates, targetOrigin }),
+    [locale, debugMode, enableInspectorMode, enableLiveUpdates, targetOrigin]
   );
 
   return (
@@ -148,7 +155,7 @@ export function useContentfulLiveUpdates<T extends Argument | null | undefined>(
     }
 
     // or update content through live updates
-    return ContentfulLivePreview.subscribe({
+    return ContentfulLivePreview.subscribe('edit', {
       data: data as Argument,
       locale: options.locale,
       query: options.query,

--- a/packages/live-preview-sdk/src/rest/__tests__/entities.test.ts
+++ b/packages/live-preview-sdk/src/rest/__tests__/entities.test.ts
@@ -31,6 +31,7 @@ const asset = assetJSON as unknown as Asset;
 const dataFromPreviewApp = dataFromPreviewAppJSON as unknown as Entry;
 
 describe('Update REST entry', () => {
+  const sendMessage = vi.fn();
   const defaultEntityReferenceMap = new Map<string, Entry | Asset>([
     [newEntryReference.sys.id, newEntryReference],
     [newAssetReference.sys.id, newAssetReference],
@@ -44,6 +45,7 @@ describe('Update REST entry', () => {
       } as unknown as Entry,
     ],
   ]);
+
   beforeEach(() => {
     (resolveReference as Mock).mockImplementation(async ({ referenceId }) => {
       return { reference: defaultEntityReferenceMap.get(referenceId) };
@@ -76,7 +78,8 @@ describe('Update REST entry', () => {
       locale,
       entityReferenceMap,
       0,
-      visitedReferences
+      visitedReferences,
+      sendMessage
     );
   };
 

--- a/packages/live-preview-sdk/src/types.ts
+++ b/packages/live-preview-sdk/src/types.ts
@@ -1,6 +1,8 @@
 import type { Asset, Entry } from 'contentful';
 import type { ContentTypeProps } from 'contentful-management';
 
+import { SendMessage } from './helpers';
+
 export type ContentType = ContentTypeProps;
 export const ASSET_TYPENAME = 'Asset';
 
@@ -63,6 +65,7 @@ export type UpdateEntryProps = {
   locale: string;
   entityReferenceMap: EntityReferenceMap;
   gqlParams?: GraphQLParams;
+  sendMessage: SendMessage;
 };
 
 export type UpdateFieldProps = {
@@ -72,6 +75,7 @@ export type UpdateFieldProps = {
   locale: string;
   entityReferenceMap: EntityReferenceMap;
   gqlParams?: GraphQLParams;
+  sendMessage: SendMessage;
 };
 
 export type UpdateReferenceFieldProps = {
@@ -80,6 +84,7 @@ export type UpdateReferenceFieldProps = {
   entityReferenceMap: EntityReferenceMap;
   locale: string;
   gqlParams?: GraphQLParams;
+  sendMessage: SendMessage;
 };
 
 /**


### PR DESCRIPTION
Allow overriding the targetOrigin which is used to restrict the messaging between contentful and this SDK.
Currently, we're always sending it to app.contentful.com and app.eu.contentful.com, which produces an error for each message in the console.
Developers setting up the SDK can not configure it only for one instance of contentful and don't get the misleading errors anymore.

Why do we need both parameters then?
Removing them and using only one would be a breaking change