### PR TITLE
fix: fixing circular ref updates by using store of already fetched data []

### DIFF
--- a/packages/live-preview-sdk/src/rest/__tests__/entities.test.ts
+++ b/packages/live-preview-sdk/src/rest/__tests__/entities.test.ts
@@ -6,7 +6,7 @@ import contentTypeAsset from '../../__tests__/fixtures/contentTypeAsset.json';
 import { MAX_DEPTH } from '../../constants';
 import { clone, resolveReference } from '../../helpers';
 import { EntityReferenceMap } from '../../types';
-import { updateEntity } from '../entities';
+import { Reference, updateEntity } from '../entities';
 import { EN, referenceWithRichTextId } from './constants';
 import contentTypeEntryJSON from './fixtures/contentType.json';
 import {
@@ -67,7 +67,7 @@ describe('Update REST entry', () => {
     locale?: string;
     entityReferenceMap?: EntityReferenceMap;
   }) => {
-    const visitedReferences = new Set<string>();
+    const visitedReferences = new Map<string, Reference>();
 
     return updateEntity(
       contentType,

--- a/packages/live-preview-sdk/src/rest/entities.ts
+++ b/packages/live-preview-sdk/src/rest/entities.ts
@@ -45,7 +45,6 @@ async function updateRef(
       : updateFromEntryEditor.sys.id;
 
   // If the ID of the updateFromEntryEditor is in visitedReferences, then stop the recursion
-  // if (visitedReferences.has(updateFromEntryEditor.sys.id)) {
   if (visitedReferenceMap.has(id)) {
     debug.warn('Detected a circular reference, stopping recursion');
     reference = visitedReferenceMap.get(id);

--- a/packages/live-preview-sdk/src/rest/index.ts
+++ b/packages/live-preview-sdk/src/rest/index.ts
@@ -1,1 +1,2 @@
 export { updateEntity } from './entities';
+export type { Reference } from './entities';


### PR DESCRIPTION
For circular references we were getting links instead of resolved entities when the same references is linked twice in the page