### PR TITLE
fix(gql): inifite loop with circular references []

### DIFF
--- a/packages/live-preview-sdk/src/constants.ts
+++ b/packages/live-preview-sdk/src/constants.ts
@@ -9,6 +9,7 @@ export const TOOLTIP_HEIGHT = 32;
 export const TOOLTIP_PADDING_LEFT = 5;
 
 export const MAX_DEPTH = 10;
+export const MAX_RTE_DEPTH = 2;
 
 export const LIVE_PREVIEW_EDITOR_SOURCE = 'live-preview-editor' as const;
 export const LIVE_PREVIEW_SDK_SOURCE = 'live-preview-sdk' as const;

--- a/packages/live-preview-sdk/src/graphql/__tests__/entries.test.ts
+++ b/packages/live-preview-sdk/src/graphql/__tests__/entries.test.ts
@@ -8,6 +8,7 @@ import type { SysProps, Entity, ContentType, GetStore } from '../../types';
 import { updateEntry } from '../entries';
 import defaultContentTypeJSON from './fixtures/contentType.json';
 import entry from './fixtures/entry.json';
+import { MAX_DEPTH } from '../../constants';
 
 const EN = 'en-US';
 
@@ -58,7 +59,7 @@ describe('Update GraphQL Entry', () => {
       updateFromEntryEditor: update,
       locale,
       getStore,
-      depth: 0,
+      maxDepth: MAX_DEPTH,
     });
   };
 

--- a/packages/live-preview-sdk/src/graphql/__tests__/entries.test.ts
+++ b/packages/live-preview-sdk/src/graphql/__tests__/entries.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, afterEach, beforeEach, Mock } from 'vitest';
 
 import * as Utils from '../../helpers';
 import { resolveReference } from '../../helpers/resolveReference';
-import { SysProps, EntityReferenceMap, Entity, ContentType } from '../../types';
+import type { SysProps, Entity, ContentType, GetStore } from '../../types';
 import { updateEntry } from '../entries';
 import defaultContentTypeJSON from './fixtures/contentType.json';
 import entry from './fixtures/entry.json';
@@ -19,7 +19,7 @@ const defaultContentType = defaultContentTypeJSON as ContentTypeProps;
 // Note: we can get rid of expect.objectContaining, if we iterate over the provided data instead of the ContentType.fields
 describe('Update GraphQL Entry', () => {
   const testReferenceId = '18kDTlnJNnDIJf6PsXE5Mr';
-  const sendMessage = vi.fn();
+  const getStore = vi.fn<Parameters<GetStore>, ReturnType<GetStore>>();
 
   beforeEach(() => {
     (resolveReference as Mock).mockResolvedValue({
@@ -45,13 +45,11 @@ describe('Update GraphQL Entry', () => {
     data,
     update = entry as unknown as Entry,
     locale = EN,
-    entityReferenceMap = new EntityReferenceMap(),
     contentType = defaultContentType,
   }: {
     data: Entity & { sys: SysProps };
     update?: Entry;
     locale?: string;
-    entityReferenceMap?: EntityReferenceMap;
     contentType?: ContentType;
   }) => {
     return updateEntry({
@@ -59,8 +57,8 @@ describe('Update GraphQL Entry', () => {
       dataFromPreviewApp: data,
       updateFromEntryEditor: update,
       locale,
-      entityReferenceMap,
-      sendMessage,
+      getStore,
+      depth: 0,
     });
   };
 

--- a/packages/live-preview-sdk/src/helpers/resolveReference.ts
+++ b/packages/live-preview-sdk/src/helpers/resolveReference.ts
@@ -7,7 +7,7 @@ import {
 import type { Asset, Entry } from 'contentful';
 
 import { generateTypeName } from '../graphql/utils';
-import { ASSET_TYPENAME, EntityReferenceMap } from '../types';
+import { ASSET_TYPENAME, ReferenceMap } from '../types';
 
 const store: Record<string, EditorEntityStore> = {};
 
@@ -42,39 +42,39 @@ function getStore(locale: string, sendMessage: SendMessage): EditorEntityStore {
 }
 
 export async function resolveReference(info: {
-  entityReferenceMap: EntityReferenceMap;
   referenceId: string;
   locale: string;
   sendMessage: SendMessage;
+  referenceMap: ReferenceMap;
 }): Promise<{ reference: Entry; typeName: string }>;
 export async function resolveReference(info: {
-  entityReferenceMap: EntityReferenceMap;
   referenceId: string;
   isAsset: true;
   locale: string;
   sendMessage: SendMessage;
+  referenceMap: ReferenceMap;
 }): Promise<{ reference: Asset; typeName: string }>;
 /**
  * Returns the requested reference from
- * 1) the entityReferenceMap if it was already resolved once
+ * 1) the referenceMap if it was already resolved once
  * 2) loads it from the editor directly
  */
 export async function resolveReference({
-  entityReferenceMap,
   referenceId,
   isAsset,
   locale,
   sendMessage,
+  referenceMap,
 }: {
-  entityReferenceMap: EntityReferenceMap;
   referenceId: string;
   isAsset?: boolean;
   locale: string;
   sendMessage: SendMessage;
+  referenceMap: ReferenceMap;
 }): Promise<{ reference: Entry | Asset; typeName: string }> {
-  const reference = entityReferenceMap.get(referenceId);
-
+  const reference = referenceMap.get(referenceId);
   if (reference) {
+    referenceMap.set(referenceId, reference);
     return {
       reference,
       typeName:
@@ -101,6 +101,7 @@ export async function resolveReference({
     throw new Error(`Unknown reference ${referenceId}`);
   }
 
+  referenceMap.set(referenceId, result);
   return {
     reference: result,
     typeName: generateTypeName(result.sys.contentType.sys.id),

--- a/packages/live-preview-sdk/src/helpers/resolveReference.ts
+++ b/packages/live-preview-sdk/src/helpers/resolveReference.ts
@@ -30,8 +30,10 @@ export async function resolveReference({
   locale: string;
   getStore: GetStore;
 }): Promise<{ reference: Entry | Asset; typeName: string }> {
+  const store = getStore(locale);
+
   if (isAsset) {
-    const result = await getStore(locale).fetchAsset(referenceId);
+    const result = await store.fetchAsset(referenceId);
     if (!result) {
       throw new Error(`Unknown reference ${referenceId}`);
     }
@@ -42,7 +44,7 @@ export async function resolveReference({
     };
   }
 
-  const result = await getStore(locale).fetchEntry(referenceId);
+  const result = await store.fetchEntry(referenceId);
   if (!result) {
     throw new Error(`Unknown reference ${referenceId}`);
   }

--- a/packages/live-preview-sdk/src/helpers/resolveReference.ts
+++ b/packages/live-preview-sdk/src/helpers/resolveReference.ts
@@ -1,91 +1,37 @@
-import {
-  EditorEntityStore,
-  PostMessageMethods,
-  RequestEntitiesMessage,
-  RequestedEntitiesMessage,
-} from '@contentful/visual-sdk';
 import type { Asset, Entry } from 'contentful';
 
 import { generateTypeName } from '../graphql/utils';
-import { ASSET_TYPENAME, ReferenceMap } from '../types';
-
-const store: Record<string, EditorEntityStore> = {};
-
-export type SendMessage = (method: PostMessageMethods, params: RequestEntitiesMessage) => void;
-
-function getStore(locale: string, sendMessage: SendMessage): EditorEntityStore {
-  if (!store[locale]) {
-    store[locale] = new EditorEntityStore({
-      entities: [],
-      sendMessage,
-      subscribe: (method, cb) => {
-        // TODO: move this to a generic subscribe function on ContentfulLivePreview
-        const listeners = (
-          event: MessageEvent<RequestedEntitiesMessage & { from: 'live-preview'; method: string }>
-        ) => {
-          if (typeof event.data !== 'object' || !event.data) return;
-          if (event.data.from !== 'live-preview') return;
-          if (event.data.method === method) {
-            cb(event.data);
-          }
-        };
-
-        window.addEventListener('message', listeners);
-
-        return () => window.removeEventListener('message', listeners);
-      },
-      locale,
-    });
-  }
-
-  return store[locale];
-}
+import { ASSET_TYPENAME, GetStore } from '../types';
 
 export async function resolveReference(info: {
   referenceId: string;
   locale: string;
-  sendMessage: SendMessage;
-  referenceMap: ReferenceMap;
+  getStore: GetStore;
 }): Promise<{ reference: Entry; typeName: string }>;
 export async function resolveReference(info: {
   referenceId: string;
   isAsset: true;
   locale: string;
-  sendMessage: SendMessage;
-  referenceMap: ReferenceMap;
+  getStore: GetStore;
 }): Promise<{ reference: Asset; typeName: string }>;
 /**
  * Returns the requested reference from
- * 1) the referenceMap if it was already resolved once
+ * 1) the store if it was already resolved once
  * 2) loads it from the editor directly
  */
 export async function resolveReference({
   referenceId,
   isAsset,
   locale,
-  sendMessage,
-  referenceMap,
+  getStore,
 }: {
   referenceId: string;
   isAsset?: boolean;
   locale: string;
-  sendMessage: SendMessage;
-  referenceMap: ReferenceMap;
+  getStore: GetStore;
 }): Promise<{ reference: Entry | Asset; typeName: string }> {
-  const reference = referenceMap.get(referenceId);
-  if (reference) {
-    referenceMap.set(referenceId, reference);
-    return {
-      reference,
-      typeName:
-        'contentType' in reference.sys && reference.sys?.contentType?.sys?.id
-          ? generateTypeName(reference.sys.contentType.sys.id)
-          : ASSET_TYPENAME,
-    };
-  }
-
   if (isAsset) {
-    const result = await getStore(locale, sendMessage).fetchAsset(referenceId);
+    const result = await getStore(locale).fetchAsset(referenceId);
     if (!result) {
       throw new Error(`Unknown reference ${referenceId}`);
     }
@@ -96,12 +42,11 @@ export async function resolveReference({
     };
   }
 
-  const result = await getStore(locale, sendMessage).fetchEntry(referenceId);
+  const result = await getStore(locale).fetchEntry(referenceId);
   if (!result) {
     throw new Error(`Unknown reference ${referenceId}`);
   }
 
-  referenceMap.set(referenceId, result);
   return {
     reference: result,
     typeName: generateTypeName(result.sys.contentType.sys.id),

--- a/packages/live-preview-sdk/src/liveUpdates.ts
+++ b/packages/live-preview-sdk/src/liveUpdates.ts
@@ -26,6 +26,7 @@ import {
   GraphQLParams,
 } from './types';
 import { EditorEntityStore } from '@contentful/visual-sdk';
+import { MAX_DEPTH } from './constants';
 
 interface MergeEntityProps {
   dataFromPreviewApp: Entity;
@@ -54,6 +55,7 @@ export class LiveUpdates {
     this.defaultLocale = locale;
     this.sendMessage = (method, data) => sendMessageToEditor(method, data, targetOrigin);
     this.storage = new StorageMap<Entity>('live-updates', new Map());
+    this.getStore = this.getStore.bind(this);
     window.addEventListener('beforeunload', () => this.clearStorage());
   }
 
@@ -97,8 +99,6 @@ export class LiveUpdates {
     data: Entity;
     updated: boolean;
   }> {
-    const depth = 0;
-
     if ('__typename' in dataFromPreviewApp) {
       // GraphQL
       const data = await (dataFromPreviewApp.__typename === 'Asset'
@@ -109,7 +109,7 @@ export class LiveUpdates {
             updateFromEntryEditor: updateFromEntryEditor as Entry,
             locale,
             gqlParams,
-            depth,
+            maxDepth: MAX_DEPTH,
             getStore: this.getStore,
           }));
 
@@ -127,7 +127,7 @@ export class LiveUpdates {
           dataFromPreviewApp as Entry,
           updateFromEntryEditor as Entry,
           locale,
-          depth,
+          MAX_DEPTH,
           this.getStore
         ),
         updated: true,

--- a/packages/live-preview-sdk/src/types.ts
+++ b/packages/live-preview-sdk/src/types.ts
@@ -67,7 +67,7 @@ export type UpdateEntryProps = {
   locale: string;
   gqlParams?: GraphQLParams;
   getStore: GetStore;
-  depth: number;
+  maxDepth: number;
 };
 
 export type UpdateFieldProps = {
@@ -77,7 +77,7 @@ export type UpdateFieldProps = {
   locale: string;
   gqlParams?: GraphQLParams;
   getStore: GetStore;
-  depth: number;
+  maxDepth: number;
 };
 
 export type UpdateReferenceFieldProps = {
@@ -86,7 +86,7 @@ export type UpdateReferenceFieldProps = {
   locale: string;
   gqlParams?: GraphQLParams;
   getStore: GetStore;
-  depth: number;
+  maxDepth: number;
 };
 
 /**

--- a/packages/live-preview-sdk/src/types.ts
+++ b/packages/live-preview-sdk/src/types.ts
@@ -1,7 +1,7 @@
 import type { Asset, Entry } from 'contentful';
 import type { ContentTypeProps } from 'contentful-management';
 
-import { SendMessage } from './helpers';
+import { EditorEntityStore } from '@contentful/visual-sdk';
 
 export type ContentType = ContentTypeProps;
 export const ASSET_TYPENAME = 'Asset';
@@ -56,7 +56,9 @@ export interface CollectionItem {
   __typename?: string;
 }
 
-export type ReferenceMap = Map<string, Entry | Asset>;
+export type EntityReferenceMap = Map<string, Asset | Entry>;
+
+export type GetStore = (locale: string) => EditorEntityStore;
 
 export type UpdateEntryProps = {
   contentType: ContentType;
@@ -64,9 +66,8 @@ export type UpdateEntryProps = {
   updateFromEntryEditor: Entry;
   locale: string;
   gqlParams?: GraphQLParams;
-  sendMessage: SendMessage;
+  getStore: GetStore;
   depth: number;
-  referenceMap: ReferenceMap;
 };
 
 export type UpdateFieldProps = {
@@ -75,9 +76,8 @@ export type UpdateFieldProps = {
   name: string;
   locale: string;
   gqlParams?: GraphQLParams;
-  sendMessage: SendMessage;
+  getStore: GetStore;
   depth: number;
-  referenceMap: ReferenceMap;
 };
 
 export type UpdateReferenceFieldProps = {
@@ -85,9 +85,8 @@ export type UpdateReferenceFieldProps = {
   updatedReference?: (Pick<Entry, 'sys'> | Pick<Asset, 'sys'>) & { __typename?: string };
   locale: string;
   gqlParams?: GraphQLParams;
-  sendMessage: SendMessage;
+  getStore: GetStore;
   depth: number;
-  referenceMap: ReferenceMap;
 };
 
 /**

--- a/packages/live-preview-sdk/src/types.ts
+++ b/packages/live-preview-sdk/src/types.ts
@@ -56,16 +56,17 @@ export interface CollectionItem {
   __typename?: string;
 }
 
-export class EntityReferenceMap extends Map<string, Entry | Asset> {}
+export type ReferenceMap = Map<string, Entry | Asset>;
 
 export type UpdateEntryProps = {
   contentType: ContentType;
   dataFromPreviewApp: Entity & { sys: SysProps };
   updateFromEntryEditor: Entry;
   locale: string;
-  entityReferenceMap: EntityReferenceMap;
   gqlParams?: GraphQLParams;
   sendMessage: SendMessage;
+  depth: number;
+  referenceMap: ReferenceMap;
 };
 
 export type UpdateFieldProps = {
@@ -73,18 +74,20 @@ export type UpdateFieldProps = {
   updateFromEntryEditor: Entry;
   name: string;
   locale: string;
-  entityReferenceMap: EntityReferenceMap;
   gqlParams?: GraphQLParams;
   sendMessage: SendMessage;
+  depth: number;
+  referenceMap: ReferenceMap;
 };
 
 export type UpdateReferenceFieldProps = {
   referenceFromPreviewApp: (Entity & { __typename?: string }) | null | undefined;
   updatedReference?: (Pick<Entry, 'sys'> | Pick<Asset, 'sys'>) & { __typename?: string };
-  entityReferenceMap: EntityReferenceMap;
   locale: string;
   gqlParams?: GraphQLParams;
   sendMessage: SendMessage;
+  depth: number;
+  referenceMap: ReferenceMap;
 };
 
 /**


### PR DESCRIPTION
- Use the depth limit for GraphQL if no gqlParams have been provided, to prevent an endless loop of updates for circular references
- Drop VisitedReferencesMap and EntityReferenceMap in favor of the EditorEntityStore
- Move the store up on a higher level to be better accessible and increase update speed
- Move the depth handling the other way around, instead of increase the depth, decrease the remaining depth
- Additionally define a custom depth for rich text (only two levels instead of max 10)