### PR TITLE
fix(entity-store): split into asset and entry map to prevent id collision

### DIFF
--- a/packages/visual-sdk/src/store/EditorStore.spec.ts
+++ b/packages/visual-sdk/src/store/EditorStore.spec.ts
@@ -22,6 +22,21 @@ describe('EntityStore', () => {
     expect(createStore().entities).toEqual(entities);
   });
 
+  it('prevents id collision for assets and entries', async () => {
+    const patchedAsset = { ...asset, sys: { ...asset.sys, id: '1' } };
+    const patchedEntry = { ...entry, sys: { ...entry.sys, id: '1' } };
+
+    const store = new EntityStore({ entities: [patchedAsset, patchedEntry], locale });
+
+    const [resolvedAsset, resolvedEntry] = await Promise.all([
+      store.fetchAsset('1'),
+      store.fetchEntry('1'),
+    ]);
+
+    expect(resolvedAsset).toEqual(patchedAsset);
+    expect(resolvedEntry).toEqual(patchedEntry);
+  });
+
   describe('getValue', () => {
     it('should return the value based on entityId and path', () => {
       const store = createStore();

--- a/packages/visual-sdk/src/store/EntityStore.ts
+++ b/packages/visual-sdk/src/store/EntityStore.ts
@@ -8,28 +8,33 @@ import { get } from './utils';
  */
 export class EntityStore {
   protected locale: string;
-  protected entitiesMap: Map<string, Entry | Asset>;
+  protected entryMap = new Map<string, Entry>();
+  protected assetMap = new Map<string, Asset>();
 
   constructor({ entities, locale }: { entities: Array<Entry | Asset>; locale: string }) {
-    this.entitiesMap = new Map(entities.map((entity) => [entity.sys.id, entity]));
     this.locale = locale;
+
+    for (const entity of entities) {
+      this.addEntity(entity);
+    }
   }
 
   public get entities() {
-    return [...this.entitiesMap.values()];
+    return [...this.entryMap.values(), ...this.assetMap.values()];
   }
 
   public updateEntity(entity: Entry | Asset) {
-    this.entitiesMap.set(entity.sys.id, entity);
+    this.addEntity(entity);
   }
 
   public getValue(
     entityLink: UnresolvedLink<'Entry' | 'Asset'>,
     path: string[]
   ): string | undefined {
-    const entity = this.entitiesMap.get(entityLink.sys.id);
+    entityLink.sys.type;
+    const entity = this.getEntity(entityLink.sys.linkType, entityLink.sys.id);
 
-    if (!entity || entity.sys.type !== entityLink.sys.linkType) {
+    if (!entity) {
       // TODO: move to `debug` utils once it is extracted
       console.warn(`Unresolved entity reference: ${entityLink}`);
       return;
@@ -38,50 +43,79 @@ export class EntityStore {
     return get<string>(entity, path);
   }
 
-  private getEntitiesFromMap(ids: string[]) {
-    const entity = [];
-    const missingEntityIds = [];
+  protected getEntitiesFromMap(type: 'Entry' | 'Asset', ids: string[]) {
+    const resolved = [];
+    const missing = [];
 
     for (const id of ids) {
-      const entry = this.entitiesMap.get(id);
-      if (entry) {
-        entity.push(entry);
+      const entity = this.getEntity(type, id);
+      if (entity) {
+        resolved.push(entity);
       } else {
-        missingEntityIds.push(id);
+        missing.push(id);
       }
     }
 
-    if (missingEntityIds.length) {
-      throw new Error(`Missing entity in the store (${missingEntityIds.join(',')})`);
-    }
+    return {
+      resolved,
+      missing,
+    };
+  }
 
-    return entity as Array<Asset | Entry>;
+  protected addEntity(entity: Entry | Asset): void {
+    if (this.isAsset(entity)) {
+      this.assetMap.set(entity.sys.id, entity);
+    } else {
+      this.entryMap.set(entity.sys.id, entity);
+    }
   }
 
   public async fetchAsset(id: string): Promise<Asset | undefined> {
-    try {
-      return this.getEntitiesFromMap([id])[0] as Asset;
-    } catch (err) {
+    const { resolved, missing } = this.getEntitiesFromMap('Asset', [id]);
+    if (missing.length) {
       // TODO: move to `debug` utils once it is extracted
       console.warn(`Asset "${id}" is not in the store`);
       return undefined;
     }
+
+    return resolved[0] as Asset;
   }
   public async fetchAssets(ids: string[]): Promise<Asset[]> {
-    return this.getEntitiesFromMap(ids) as Asset[];
+    const { resolved, missing } = this.getEntitiesFromMap('Asset', ids);
+    if (missing.length) {
+      throw new Error(`Missing assets in the store (${missing.join(',')})`);
+    }
+    return resolved as Asset[];
   }
 
   public async fetchEntry(id: string): Promise<Entry | undefined> {
-    try {
-      return this.getEntitiesFromMap([id])[0] as Entry;
-    } catch (err) {
+    const { resolved, missing } = this.getEntitiesFromMap('Entry', [id]);
+    if (missing.length) {
       // TODO: move to `debug` utils once it is extracted
       console.warn(`Entry "${id}" is not in the store`);
       return undefined;
     }
+
+    return resolved[0] as Entry;
   }
 
   public async fetchEntries(ids: string[]): Promise<Entry[]> {
-    return this.getEntitiesFromMap(ids) as Entry[];
+    const { resolved, missing } = this.getEntitiesFromMap('Entry', ids);
+    if (missing.length) {
+      throw new Error(`Missing assets in the store (${missing.join(',')})`);
+    }
+    return resolved as Entry[];
+  }
+
+  private isAsset(entity: Entry | Asset): entity is Asset {
+    return entity.sys.type === 'Asset';
+  }
+
+  private getEntity(type: 'Asset' | 'Entry', id: string) {
+    if (type === 'Asset') {
+      return this.assetMap.get(id);
+    }
+
+    return this.entryMap.get(id);
   }
 }


### PR DESCRIPTION
Entry and Asset can have the same ID, therefore we should split up the entities into two maps (one for asset, one for entry)