### PR TITLE
fix(validation): warn about invalid query usage on live updates subscription []

### DIFF
--- a/packages/live-preview-sdk/src/__tests__/validation.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/validation.spec.ts
@@ -1,177 +1,330 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
 import { debug } from '../helpers';
-import { validateDataForLiveUpdates } from '../helpers/validation';
+import { validateLiveUpdatesConfiguration } from '../helpers/validation';
+import gql from 'graphql-tag';
 
 vi.mock('../helpers/debug');
 
-describe('validateDataForLiveUpdates', () => {
+describe('validateLiveUpdatesConfiguration', () => {
+  const callback = vi.fn();
+
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('REST', () => {
-    it('detects REST structure on the top level', () => {
-      const result = validateDataForLiveUpdates({
-        sys: { id: '123' },
-        fields: {
-          title: { 'en-US': 'Hello World' },
-        },
-      });
-
-      expect(debug.error).not.toHaveBeenCalled();
-
-      expect(result).toEqual({
-        isGQL: false,
-        isREST: true,
-        sysId: '123',
-        isValid: true,
-      });
-    });
-
-    it('detects REST structure inside lists', () => {
-      const result = validateDataForLiveUpdates([
-        {
-          sys: { id: '123' },
-          fields: {
-            title: { 'en-US': 'Hello World' },
-          },
-        },
-      ]);
-
-      expect(debug.error).not.toHaveBeenCalled();
-
-      expect(result).toEqual({
-        isGQL: false,
-        isREST: true,
-        sysId: '123',
-        isValid: true,
-      });
-    });
-
-    it('detects REST structure in a nested structure', () => {
-      const result = validateDataForLiveUpdates({
-        items: [
-          {
+  describe('config.data', () => {
+    describe('REST', () => {
+      it('detects REST structure on the top level', () => {
+        const config = {
+          callback,
+          data: {
             sys: { id: '123' },
             fields: {
               title: { 'en-US': 'Hello World' },
             },
           },
-        ],
+        };
+        const result = validateLiveUpdatesConfiguration(config);
+
+        expect(debug.error).not.toHaveBeenCalled();
+
+        expect(result).toEqual({
+          isGQL: false,
+          isREST: true,
+          sysId: '123',
+          isValid: true,
+          config,
+        });
       });
 
-      expect(debug.error).not.toHaveBeenCalled();
+      it('detects REST structure inside lists', () => {
+        const config = {
+          callback,
+          data: [
+            {
+              sys: { id: '123' },
+              fields: {
+                title: { 'en-US': 'Hello World' },
+              },
+            },
+          ],
+        };
+        const result = validateLiveUpdatesConfiguration(config);
 
-      expect(result).toEqual({
-        isGQL: false,
-        isREST: true,
-        sysId: '123',
-        isValid: true,
+        expect(debug.error).not.toHaveBeenCalled();
+
+        expect(result).toEqual({
+          isGQL: false,
+          isREST: true,
+          sysId: '123',
+          isValid: true,
+          config,
+        });
+      });
+
+      it('detects REST structure in a nested structure', () => {
+        const config = {
+          callback,
+          data: {
+            items: [
+              {
+                sys: { id: '123' },
+                fields: {
+                  title: { 'en-US': 'Hello World' },
+                },
+              },
+            ],
+          },
+        };
+        const result = validateLiveUpdatesConfiguration(config);
+
+        expect(debug.error).not.toHaveBeenCalled();
+
+        expect(result).toEqual({
+          isGQL: false,
+          isREST: true,
+          sysId: '123',
+          isValid: true,
+          config,
+        });
       });
     });
-  });
 
-  describe('GraphQL', () => {
-    it('detects GraphQL structure on the top level', () => {
-      const result = validateDataForLiveUpdates({
-        sys: { id: '123' },
-        title: { 'en-US': 'Hello World' },
-        __typename: 'hello',
+    describe('GraphQL', () => {
+      it('detects GraphQL structure on the top level', () => {
+        const config = {
+          callback,
+          data: {
+            sys: { id: '123' },
+            title: { 'en-US': 'Hello World' },
+            __typename: 'hello',
+          },
+        };
+        const result = validateLiveUpdatesConfiguration(config);
+
+        expect(debug.error).not.toHaveBeenCalled();
+
+        expect(result).toEqual({
+          isGQL: true,
+          isREST: false,
+          sysId: '123',
+          isValid: true,
+          config,
+        });
       });
 
-      expect(debug.error).not.toHaveBeenCalled();
-
-      expect(result).toEqual({
-        isGQL: true,
-        isREST: false,
-        sysId: '123',
-        isValid: true,
-      });
-    });
-
-    it('detects REST structure inside lists', () => {
-      const result = validateDataForLiveUpdates([
-        {
-          sys: { id: '123' },
-          title: { 'en-US': 'Hello World' },
-          __typename: 'hello',
-        },
-      ]);
-
-      expect(debug.error).not.toHaveBeenCalled();
-
-      expect(result).toEqual({
-        isGQL: true,
-        isREST: false,
-        sysId: '123',
-        isValid: true,
-      });
-    });
-
-    it('detects REST structure in a nested structure', () => {
-      const result = validateDataForLiveUpdates({
-        collection: {
-          items: [
+      it('detects REST structure inside lists', () => {
+        const config = {
+          callback,
+          data: [
             {
               sys: { id: '123' },
               title: { 'en-US': 'Hello World' },
               __typename: 'hello',
             },
           ],
-        },
+        };
+        const result = validateLiveUpdatesConfiguration(config);
+
+        expect(debug.error).not.toHaveBeenCalled();
+
+        expect(result).toEqual({
+          isGQL: true,
+          isREST: false,
+          sysId: '123',
+          isValid: true,
+          config,
+        });
       });
 
-      expect(debug.error).not.toHaveBeenCalled();
+      it('detects REST structure in a nested structure', () => {
+        const config = {
+          callback,
+          data: {
+            collection: {
+              items: [
+                {
+                  sys: { id: '123' },
+                  title: { 'en-US': 'Hello World' },
+                  __typename: 'hello',
+                },
+              ],
+            },
+          },
+        };
+        const result = validateLiveUpdatesConfiguration(config);
+
+        expect(debug.error).not.toHaveBeenCalled();
+
+        expect(result).toEqual({
+          isGQL: true,
+          isREST: false,
+          sysId: '123',
+          isValid: true,
+          config,
+        });
+      });
+    });
+
+    describe('invalid', () => {
+      it('warns about missing sys information', () => {
+        const data = {
+          title: { 'en-US': 'Hello World' },
+          __typename: 'hello',
+        };
+        const config = {
+          callback,
+          data,
+        };
+        const result = validateLiveUpdatesConfiguration(config);
+
+        expect(debug.error).toHaveBeenCalledTimes(1);
+        expect(debug.error).toHaveBeenCalledWith(
+          'Live Updates requires the "sys.id" to be present on the provided data',
+          data
+        );
+
+        expect(result).toEqual({
+          isGQL: true,
+          isREST: false,
+          sysId: null,
+          isValid: false,
+          config,
+        });
+      });
+
+      it('warns that it is neither REST or GraphQL', () => {
+        const data = {
+          sys: { id: '1' },
+        };
+        const config = { callback, data };
+        const result = validateLiveUpdatesConfiguration(config);
+
+        expect(debug.error).toHaveBeenCalledTimes(1);
+        expect(debug.error).toHaveBeenCalledWith(
+          'For live updates as a basic requirement the provided data must include the "fields" property for REST or "__typename" for Graphql, otherwise the data will be treated as invalid and live updates are not applied.',
+          data
+        );
+
+        expect(result).toEqual({
+          isGQL: false,
+          isREST: false,
+          sysId: '1',
+          isValid: false,
+          config,
+        });
+      });
+    });
+  });
+
+  describe('config.query', () => {
+    it('does nothing if the provided query is valid', () => {
+      const config = {
+        callback,
+        data: {
+          sys: { id: '123' },
+          title: { 'en-US': 'Hello World' },
+          __typename: 'hello',
+        },
+        query: gql`
+          query test {
+            __typename
+            sys {
+              id
+            }
+            title
+          }
+        `,
+      };
+
+      const result = validateLiveUpdatesConfiguration(config);
+
+      expect(debug.warn).not.toHaveBeenCalled();
 
       expect(result).toEqual({
         isGQL: true,
         isREST: false,
         sysId: '123',
         isValid: true,
+        config,
       });
     });
-  });
 
-  describe('invalid', () => {
-    it('warns about missing sys information', () => {
-      const data = {
-        title: { 'en-US': 'Hello World' },
-        __typename: 'hello',
+    it('warns about invalid query and removes the query param', () => {
+      const config = {
+        callback,
+        data: {
+          sys: { id: '123' },
+          title: { 'en-US': 'Hello World' },
+          __typename: 'hello',
+        },
+        query: `
+          query test {
+            __typename
+            sys { id }
+            title
+          }
+        ` as any, // Needed to convince typescript, more a test for non typescript consumers
       };
-      const result = validateDataForLiveUpdates(data);
 
-      expect(debug.error).toHaveBeenCalledTimes(1);
-      expect(debug.error).toHaveBeenCalledWith(
-        'Live Updates requires the "sys.id" to be present on the provided data',
-        data
+      const result = validateLiveUpdatesConfiguration(config);
+
+      expect(debug.warn).toHaveBeenCalledTimes(1);
+      expect(debug.warn).toHaveBeenCalledWith(
+        'The provided GraphQL query needs to be a `DocumentNode`, please provide it in the correct format.',
+        config
       );
 
       expect(result).toEqual({
         isGQL: true,
         isREST: false,
-        sysId: null,
-        isValid: false,
+        sysId: '123',
+        isValid: true,
+        config: {
+          ...config,
+          query: undefined,
+        },
       });
     });
 
-    it('warns that it is neither REST or GraphQL', () => {
-      const data = {
-        sys: { id: '1' },
+    it('warns about a query provided to REST and removes the query param', () => {
+      const config = {
+        callback,
+        data: {
+          sys: { id: '123' },
+          fields: {
+            title: { 'en-US': 'Hello World' },
+          },
+        },
+        query: gql`
+          query test {
+            __typename
+            sys {
+              id
+            }
+            title
+          }
+        `,
       };
-      const result = validateDataForLiveUpdates(data);
 
-      expect(debug.error).toHaveBeenCalledTimes(1);
-      expect(debug.error).toHaveBeenCalledWith(
-        'For live updates as a basic requirement the provided data must include the "fields" property for REST or "__typename" for Graphql, otherwise the data will be treated as invalid and live updates are not applied.',
-        data
+      const result = validateLiveUpdatesConfiguration(config);
+
+      expect(debug.warn).toHaveBeenCalledTimes(1);
+      expect(debug.warn).toHaveBeenCalledWith(
+        'The query param is ignored as it can only be used together with GraphQL.',
+        config
       );
 
       expect(result).toEqual({
         isGQL: false,
-        isREST: false,
-        sysId: '1',
-        isValid: false,
+        isREST: true,
+        sysId: '123',
+        isValid: true,
+        config: {
+          ...config,
+          query: undefined,
+        },
       });
     });
   });

--- a/packages/live-preview-sdk/src/helpers/validation.ts
+++ b/packages/live-preview-sdk/src/helpers/validation.ts
@@ -1,10 +1,12 @@
+import type { ContentfulSubscribeConfig } from '..';
 import { Argument } from '../types';
 import { debug } from './debug';
 
-function validation(d: Argument): { isGQL: boolean; sysId: string | null; isREST: boolean } {
+// FIXME: don't go down infinite
+function validateData(d: Argument): { isGQL: boolean; sysId: string | null; isREST: boolean } {
   if (Array.isArray(d)) {
     for (const value of d) {
-      const result = validation(value);
+      const result = validateData(value);
 
       if (Object.values(result).includes(true)) {
         return result;
@@ -22,8 +24,32 @@ function validation(d: Argument): { isGQL: boolean; sysId: string | null; isREST
     }
 
     // maybe it's nested
-    return validation(Object.values(d) as Argument);
+    return validateData(Object.values(d) as Argument);
   }
+}
+
+function validatedConfig(originalConfig: ContentfulSubscribeConfig, isREST: boolean) {
+  const config = { ...originalConfig };
+
+  if (config.query) {
+    if (typeof config.query !== 'object') {
+      debug.warn(
+        'The provided GraphQL query needs to be a `DocumentNode`, please provide it in the correct format.',
+        originalConfig
+      );
+      config.query = undefined;
+    }
+
+    if (isREST) {
+      debug.warn(
+        'The query param is ignored as it can only be used together with GraphQL.',
+        originalConfig
+      );
+      config.query = undefined;
+    }
+  }
+
+  return config;
 }
 
 type ValidationResult = (
@@ -35,35 +61,43 @@ type ValidationResult = (
       isValid: false;
       sysId: string | null;
     }
-) & { isGQL: boolean; isREST: boolean };
+) & { isGQL: boolean; isREST: boolean; config: ContentfulSubscribeConfig };
 
 /**
- * **Basic** validating of the subscribed data
+ * **Basic** validating of the subscribed configuration
  * Is it GraphQL or REST and does it contain the sys information
  */
-export function validateDataForLiveUpdates(data: Argument): ValidationResult {
-  const { isGQL, sysId, isREST } = validation(data);
+export function validateLiveUpdatesConfiguration(
+  originalConfig: ContentfulSubscribeConfig
+): ValidationResult {
+  const { isGQL, isREST, sysId } = validateData(originalConfig.data);
+  const config = validatedConfig(originalConfig, isREST);
 
   if (!sysId) {
-    debug.error('Live Updates requires the "sys.id" to be present on the provided data', data);
-    return {
-      isValid: false,
-      sysId,
-      isGQL,
-      isREST,
-    };
-  }
-
-  if (!isGQL && !isREST) {
     debug.error(
-      'For live updates as a basic requirement the provided data must include the "fields" property for REST or "__typename" for Graphql, otherwise the data will be treated as invalid and live updates are not applied.',
-      data
+      'Live Updates requires the "sys.id" to be present on the provided data',
+      config.data
     );
     return {
       isValid: false,
       sysId,
       isGQL,
       isREST,
+      config,
+    };
+  }
+
+  if (!isGQL && !isREST) {
+    debug.error(
+      'For live updates as a basic requirement the provided data must include the "fields" property for REST or "__typename" for Graphql, otherwise the data will be treated as invalid and live updates are not applied.',
+      config.data
+    );
+    return {
+      isValid: false,
+      sysId,
+      isGQL,
+      isREST,
+      config,
     };
   }
 
@@ -72,5 +106,6 @@ export function validateDataForLiveUpdates(data: Argument): ValidationResult {
     isREST,
     sysId,
     isValid: true,
+    config,
   };
 }

--- a/packages/live-preview-sdk/src/liveUpdates.ts
+++ b/packages/live-preview-sdk/src/liveUpdates.ts
@@ -12,7 +12,7 @@ import type {
 import * as gql from './graphql';
 import { parseGraphQLParams } from './graphql/queryUtils';
 import { clone, generateUID, sendMessageToEditor, StorageMap, debug } from './helpers';
-import { validateDataForLiveUpdates } from './helpers/validation';
+import { validateLiveUpdatesConfiguration } from './helpers/validation';
 import { LivePreviewPostMessageMethods } from './messages';
 import * as rest from './rest';
 import {
@@ -282,8 +282,9 @@ export class LiveUpdates {
    * Subscribe to data changes from the Editor, returns a function to unsubscribe
    * Will be called once initially for the restored data
    */
-  public subscribe(config: ContentfulSubscribeConfig): VoidFunction {
-    const { isGQL, isValid, sysId, isREST } = validateDataForLiveUpdates(config.data);
+  public subscribe(originalConfig: ContentfulSubscribeConfig): VoidFunction {
+    const { isGQL, isValid, sysId, isREST, config } =
+      validateLiveUpdatesConfiguration(originalConfig);
 
     if (!isValid) {
       this.sendErrorMessage({


### PR DESCRIPTION
- Warn if the GraphQL query is provided in the wrong format
- Warn if the query is provided on a REST setup
- Remove the invalid param to prevent breaking apps