### PR TITLE
fix: cleanup request cache after timeout [SPA-1711]

### DIFF
--- a/packages/visual-sdk/src/store/EditorEntityStore.ts
+++ b/packages/visual-sdk/src/store/EditorEntityStore.ts
@@ -104,7 +104,11 @@ export class EditorEntityStore extends EntityStore {
       );
 
       const timeout = setTimeout(() => {
-        reject(new Error('Request for entities timed out'));
+        reject(new Error(`Request for entities timed out ${this.timeoutDuration}ms} for ${cacheId}`));
+
+        this.cleanupPromise(cacheId);
+        ids.forEach((id) => this.cleanupPromise(id));
+
         unsubscribe();
       }, this.timeoutDuration);
 

--- a/packages/visual-sdk/src/store/EditorEntityStore.ts
+++ b/packages/visual-sdk/src/store/EditorEntityStore.ts
@@ -99,6 +99,8 @@ export class EditorEntityStore extends EntityStore {
             ids.forEach((id) => this.cleanupPromise(id));
 
             unsubscribe();
+          } else {
+            console.warn('Unexpected entities received in REQUESTED_ENTITIES. Ignoring this response.')
           }
         }
       );


### PR DESCRIPTION
Currently, a timed out request is kept in the request cache. So when we retry it, we directly get the same error again.

