### PR TITLE
fix: accept message when missing entity IDs are matching as well  [SPA-1711] [SPA-1673]

### DIFF
--- a/packages/visual-sdk/src/store/EditorEntityStore.ts
+++ b/packages/visual-sdk/src/store/EditorEntityStore.ts
@@ -10,6 +10,7 @@ export type RequestEntitiesMessage = {
 
 export type RequestedEntitiesMessage = {
   entities: Array<Entry | Asset>;
+  missingEntityIds?: string[]
 };
 
 export enum PostMessageMethods {
@@ -91,7 +92,11 @@ export class EditorEntityStore extends EntityStore {
       const unsubscribe = this.subscribe(
         PostMessageMethods.REQUESTED_ENTITIES,
         (message: RequestedEntitiesMessage) => {
-          if (missing.every((id) => message.entities.find((entity) => entity.sys.id === id))) {
+          const messageIds = [
+            ...message.entities.map((entity) => entity.sys.id),
+            ...(message.missingEntityIds ?? []),
+          ];
+          if (missing.every((id) => messageIds.find((entityId) => entityId === id))) {
             clearTimeout(timeout);
             resolve(message.entities);
 


### PR DESCRIPTION
When there are invalid links in the experience, then the visual SDK will currently not accept the `REQUESTED_ENTITIES` message. By passing the list of "failed" entity IDs, the recognition logic should be working for these edge cases as well.
![Screenshot 2023-12-21 at 16 35 41](https://github.com/contentful/live-preview/assets/9327071/da584c21-b640-4206-bd49-f97aee6f2e96)

Example messages when it failed:
![image](https://github.com/contentful/live-preview/assets/9327071/953d4d68-4f69-4bd9-9be9-b509c8f2ebe5)

