### PR TITLE
refactor: small clean up and adding tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -31,8 +31,15 @@ module.exports = {
       },
     ],
     'react/react-in-jsx-scope': 'off',
-    '@typescript-eslint/no-empty-function': 'off',
   },
+  overrides: [
+    {
+      files: ['*.test.ts(x)', '*.spec.tsx(x)'],
+      rules: {
+        '@typescript-eslint/no-empty-function': 'off',
+      },
+    },
+  ],
   settings: {
     react: { version: 'detect' },
   },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -31,6 +31,7 @@ module.exports = {
       },
     ],
     'react/react-in-jsx-scope': 'off',
+    '@typescript-eslint/no-empty-function': 'off',
   },
   settings: {
     react: { version: 'detect' },

--- a/packages/live-preview-sdk/src/__tests__/react.spec.tsx
+++ b/packages/live-preview-sdk/src/__tests__/react.spec.tsx
@@ -17,13 +17,19 @@ import { Argument } from '../types';
 const locale = 'en-US';
 
 describe('ContentfulLivePreviewProvider', () => {
-  it('should warn about the missing locale proeprty', () => {
+  it('should warn about the missing locale property', () => {
+    // Keep test log clean of unnecessary console.error noise
+    const spy = vi.spyOn(console, 'error');
+    spy.mockImplementation(() => {});
+
     expect(
       // @ts-expect-error -- case locale not provided (e.g. JavaScript usage)
       () => render(<ContentfulLivePreviewProvider>Hello World</ContentfulLivePreviewProvider>)
     ).toThrowError(
       'ContentfulLivePreviewProvider have to be called with a locale property (for example: `<ContentfulLivePreviewProvider locale="en-US">{children}</ContentfulLivePreviewProvider>`'
     );
+
+    spy.mockRestore();
   });
 });
 
@@ -56,7 +62,7 @@ describe('useContentfulLiveUpdates', () => {
     expect(result.current).toEqual(initialData);
   });
 
-  it('should bind the subscibe fn', () => {
+  it('should bind the subscribe fn', () => {
     const initialData = createData('2');
     const { unmount } = renderHook((data) => useContentfulLiveUpdates(data, locale), {
       initialProps: initialData,
@@ -154,7 +160,7 @@ describe('useContentfulLiveUpdates', () => {
     expect(counter).toEqual(2);
   });
 
-  it('shouldnt listen to changes if the initial data is empty', () => {
+  it('should not listen to changes if the initial data is empty', () => {
     const { rerender } = renderHook((data) => useContentfulLiveUpdates(data, locale), {
       initialProps: undefined as Argument | null | undefined,
       wrapper,
@@ -167,7 +173,7 @@ describe('useContentfulLiveUpdates', () => {
     expect(subscribe).not.toHaveBeenCalled();
   });
 
-  it('shouldnt listen if live updates are disabled', () => {
+  it('should not listen if live updates are disabled', () => {
     const initialData = createData('6');
     renderHook((data) => useContentfulLiveUpdates(data, locale), {
       initialProps: initialData,

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
@@ -55,27 +55,30 @@ describe('getAllTaggedElements', () => {
     it('should ignore elements without field id', () => {
       const dom = html(`
 		<div>
-		  <!-- Entries -->
-		  <div ${dataEntry}="entry-1"></div>
+		  <!-- Keep -->
+		  <div id="entry" ${dataEntry}="entry-id" ${dataField}="field-id"></div>
 
+		  <!-- Ignore -->
+		  <div ${dataEntry}="entry-1"></div>
 		  <div ${dataEntry}="entry-2" ${dataLocale}="locale-2"></div>
 
-		  <!-- Assets -->
 		  <div ${dataAsset}="asset-1"></div>
-
 		  <div ${dataAsset}="asset-2" ${dataLocale}="locale-2"></div>
 		</div>
 	  `);
 
       const elements = getAllTaggedElements(dom);
 
-      expect(elements).toEqual([]);
+      expect(elements).toEqual([dom.getElementById('entry')]);
     });
 
     it('should ignore elements without entry or asset id', () => {
       const dom = html(`
 		<div>
-		  <!-- Entries -->
+		  <!-- Keep -->
+		  <div id="entry" ${dataEntry}="entry-id" ${dataField}="field-id"></div>
+			
+		  <!-- Ignore -->
 		  <div ${dataField}="field-1"></div>
 
 		  <div ${dataField}="field-2" ${dataLocale}="locale-2"></div>
@@ -84,7 +87,7 @@ describe('getAllTaggedElements', () => {
 
       const elements = getAllTaggedElements(dom);
 
-      expect(elements).toEqual([]);
+      expect(elements).toEqual([dom.getElementById('entry')]);
     });
   });
 });

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { getAllTaggedElements } from '../utils';
+import { InspectorModeDataAttributes } from '../types';
+
+describe('getAllTaggedElements', () => {
+  const dataEntry = InspectorModeDataAttributes.ENTRY_ID;
+  const dataAsset = InspectorModeDataAttributes.ASSET_ID;
+  const dataField = InspectorModeDataAttributes.FIELD_ID;
+  const dataLocale = InspectorModeDataAttributes.LOCALE;
+
+  const html = (text: string) => {
+    return new DOMParser().parseFromString(text, 'text/html');
+  };
+
+  describe('manual tagging', () => {
+    it('should return all tagged elements', () => {
+      const dom = html(`
+		<div>
+		  <!-- Entries -->
+		  <div 
+		    id="entry-1"
+			${dataEntry}="entry-1"
+			${dataField}="field-1"></div>
+
+		  <div
+		    id="entry-2"
+			${dataEntry}="entry-2"
+			${dataField}="field-2"
+			${dataLocale}="locale-2"></div>
+
+		  <!-- Assets -->
+		  <div 
+		    id="asset-1"
+			${dataAsset}="asset-1"
+			${dataField}="field-1"></div>
+
+		  <div
+		    id="asset-2"
+			${dataAsset}="asset-2"
+			${dataField}="field-2"
+			${dataLocale}="locale-2"></div>
+		</div>
+	  `);
+
+      const elements = getAllTaggedElements(dom);
+
+      expect(elements).toEqual([
+        dom.getElementById('entry-1'),
+        dom.getElementById('entry-2'),
+        dom.getElementById('asset-1'),
+        dom.getElementById('asset-2'),
+      ]);
+    });
+
+    it('should ignore elements without field id', () => {
+      const dom = html(`
+		<div>
+		  <!-- Entries -->
+		  <div ${dataEntry}="entry-1"></div>
+
+		  <div ${dataEntry}="entry-2" ${dataLocale}="locale-2"></div>
+
+		  <!-- Assets -->
+		  <div ${dataAsset}="asset-1"></div>
+
+		  <div ${dataAsset}="asset-2" ${dataLocale}="locale-2"></div>
+		</div>
+	  `);
+
+      const elements = getAllTaggedElements(dom);
+
+      expect(elements).toEqual([]);
+    });
+
+    it('should ignore elements without entry or asset id', () => {
+      const dom = html(`
+		<div>
+		  <!-- Entries -->
+		  <div ${dataField}="field-1"></div>
+
+		  <div ${dataField}="field-2" ${dataLocale}="locale-2"></div>
+		</div>
+	  `);
+
+      const elements = getAllTaggedElements(dom);
+
+      expect(elements).toEqual([]);
+    });
+  });
+});

--- a/packages/live-preview-sdk/src/inspectorMode/index.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/index.ts
@@ -107,9 +107,7 @@ export class InspectorMode {
   /** Detects DOM changes and sends the tagged elements to the editor */
   private addMutationListener = () => {
     const mutationObserver = new MutationObserver(() => {
-      const taggedElements = getAllTaggedElements().filter(
-        (el) => !!getInspectorModeAttributes(el)
-      );
+      const taggedElements = getAllTaggedElements();
 
       if (this.taggedElements?.length !== taggedElements.length) {
         this.sendAllElements();
@@ -194,12 +192,10 @@ export class InspectorMode {
    * and sends them to the editor
    */
   private sendAllElements = () => {
-    const { targetOrigin, locale } = this.options;
-    const entries = getAllTaggedElements().filter(
-      (element) => !!getInspectorModeAttributes(element, locale)
-    );
+    const { targetOrigin } = this.options;
+    const elements = getAllTaggedElements();
 
-    this.taggedElements = entries;
+    this.taggedElements = elements;
     if (this.taggedElementMutationObserver) {
       this.taggedElementMutationObserver.disconnect();
     }
@@ -208,7 +204,7 @@ export class InspectorMode {
       sendMessageToEditor(
         InspectorModeEventMethods.TAGGED_ELEMENTS,
         {
-          elements: entries.map((e) => ({
+          elements: elements.map((e) => ({
             coordinates: e.getBoundingClientRect(),
           })),
         },

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -1,24 +1,51 @@
 import { InspectorModeAttributes, InspectorModeDataAttributes } from './types';
 
+const isTaggedElement = (node: Node): boolean => {
+  // is Element?
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return false;
+  }
+
+  const el = node as Element;
+
+  if (!el.hasAttribute(InspectorModeDataAttributes.FIELD_ID)) {
+    return false;
+  }
+
+  if (
+    !el.hasAttribute(InspectorModeDataAttributes.ENTRY_ID) &&
+    !el.hasAttribute(InspectorModeDataAttributes.ASSET_ID)
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
 /**
  * Parses the necessary information from the element and returns them.
  * If **one** of the information is missing it returns null
  */
 export function getInspectorModeAttributes(
   element: Element,
-  fallbackLocale?: string
+  fallbackLocale: string
 ): InspectorModeAttributes | null {
-  const fieldId = element.getAttribute(InspectorModeDataAttributes.FIELD_ID);
-  const entryId = element.getAttribute(InspectorModeDataAttributes.ENTRY_ID);
-  const assetId = element.getAttribute(InspectorModeDataAttributes.ASSET_ID);
-  const locale = element.getAttribute(InspectorModeDataAttributes.LOCALE) ?? fallbackLocale;
-
-  if (assetId && locale && fieldId) {
-    return { fieldId, assetId, locale };
+  if (!isTaggedElement(element)) {
+    return null;
   }
 
-  if (entryId && locale && fieldId) {
-    return { fieldId, entryId, locale };
+  const fieldId = element.getAttribute(InspectorModeDataAttributes.FIELD_ID)!;
+  const locale = element.getAttribute(InspectorModeDataAttributes.LOCALE) ?? fallbackLocale;
+
+  const entryId = element.getAttribute(InspectorModeDataAttributes.ENTRY_ID);
+  const assetId = element.getAttribute(InspectorModeDataAttributes.ASSET_ID);
+
+  if (entryId) {
+    return { entryId, fieldId, locale };
+  }
+
+  if (assetId) {
+    return { assetId, fieldId, locale };
   }
 
   return null;
@@ -26,15 +53,25 @@ export function getInspectorModeAttributes(
 
 /**
  * Query the document for all tagged elements
- * **Attention:** Can include elements that have not all attributes,
- * if you want to have only valid ones check for `getTaggedInformation`
  */
-export function getAllTaggedElements(): Element[] {
-  const allElements = [
-    ...document.querySelectorAll(`[${InspectorModeDataAttributes.ENTRY_ID}]`),
-    ...document.querySelectorAll(`[${InspectorModeDataAttributes.ASSET_ID}]`),
-  ];
-  return allElements;
+export function getAllTaggedElements(root = window.document): Element[] {
+  // The fastest way to look up & iterate over DOM. Ref:
+  // https://stackoverflow.com/a/2579869
+  //
+  // Terminology:
+  // FILTER_SKIP: Skip the current node
+  // FILTER_REJECT: Skip the current node and all its children
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ALL, (node) => {
+    return isTaggedElement(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+  });
+
+  const elements: Element[] = [];
+
+  while (walker.nextNode()) {
+    elements.push(walker.currentNode as Element);
+  }
+
+  return elements;
 }
 
 /**

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -1,7 +1,6 @@
 import { InspectorModeAttributes, InspectorModeDataAttributes } from './types';
 
 const isTaggedElement = (node: Node): boolean => {
-  // is Element?
   if (node.nodeType !== Node.ELEMENT_NODE) {
     return false;
   }

--- a/packages/live-preview-sdk/vite.config.ts
+++ b/packages/live-preview-sdk/vite.config.ts
@@ -6,6 +6,7 @@ import { configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    environment: 'jsdom',
     exclude: [
       ...configDefaults.exclude,
       'src/rest/__tests__/constants.ts',


### PR DESCRIPTION
Small cleanup:
- Suppress expected errors from test log
- Added tests for `getAllTaggedElements` and added checking for proper attributes there.
- Used `TreeWalker` for a faster & more flexible document scanning. 
- Random fixes

I opened this to keep the follow up PR small. There should be **no behavioral** change with this PR. 