### PR TITLE
feat: recognise auto-tagged elements [TOL-1711]

### DIFF
--- a/packages/live-preview-sdk/src/__tests__/csm.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/csm.spec.ts
@@ -2,9 +2,9 @@ import { vercelStegaDecode } from '@vercel/stega';
 import { describe, test, expect } from 'vitest';
 
 import { encodeSourceMap } from '../csm';
+import { SourceMapMetadata } from '../csm/encode';
 
-type Mapping = { origin: string; href: string };
-type Mappings = Record<string, Mapping | Record<string, Mapping> | undefined>;
+type Mappings = Record<string, SourceMapMetadata | Record<string, SourceMapMetadata> | undefined>;
 
 type EncodedResponse =
   | {
@@ -77,10 +77,26 @@ describe('Content Source Maps', () => {
         title: {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
+          cf: {
+            space: 'foo',
+            environment: 'master',
+            field: 'title',
+            locale: 'en-US',
+            entity: 'a1b2c3',
+            entityType: 'Entry',
+          },
         },
         subtitle: {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US',
+          cf: {
+            space: 'foo',
+            environment: 'master',
+            field: 'subtitle',
+            locale: 'en-US',
+            entity: 'a1b2c3',
+            entityType: 'Entry',
+          },
         },
       });
     });
@@ -129,10 +145,26 @@ describe('Content Source Maps', () => {
         title: {
           origin: 'contentful.com',
           href: 'https://app.eu.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
+          cf: {
+            space: 'foo',
+            environment: 'master',
+            field: 'title',
+            locale: 'en-US',
+            entity: 'a1b2c3',
+            entityType: 'Entry',
+          },
         },
         subtitle: {
           origin: 'contentful.com',
           href: 'https://app.eu.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US',
+          cf: {
+            space: 'foo',
+            environment: 'master',
+            field: 'subtitle',
+            locale: 'en-US',
+            entity: 'a1b2c3',
+            entityType: 'Entry',
+          },
         },
       });
     });
@@ -199,18 +231,42 @@ describe('Content Source Maps', () => {
           title: {
             origin: 'contentful.com',
             href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
+            cf: {
+              space: 'foo',
+              environment: 'master',
+              field: 'title',
+              locale: 'en-US',
+              entity: 'a1b2c3',
+              entityType: 'Entry',
+            },
           },
         },
         1: {
           title: {
             origin: 'contentful.com',
             href: 'https://app.contentful.com/spaces/foo/environments/master/entries/d4e5f6/?focusedField=title&focusedLocale=en-US',
+            cf: {
+              space: 'foo',
+              environment: 'master',
+              field: 'title',
+              locale: 'en-US',
+              entity: 'd4e5f6',
+              entityType: 'Entry',
+            },
           },
         },
         2: {
           title: {
             origin: 'contentful.com',
             href: 'https://app.contentful.com/spaces/foo/environments/master/entries/g7h8i9/?focusedField=title&focusedLocale=en-US',
+            cf: {
+              space: 'foo',
+              environment: 'master',
+              field: 'title',
+              locale: 'en-US',
+              entity: 'g7h8i9',
+              entityType: 'Entry',
+            },
           },
         },
       });
@@ -269,14 +325,38 @@ describe('Content Source Maps', () => {
         akanTitle: {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=ak',
+          cf: {
+            space: 'foo',
+            environment: 'master',
+            field: 'title',
+            locale: 'ak',
+            entity: 'a1b2c3',
+            entityType: 'Entry',
+          },
         },
         aghemTitle: {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=agq',
+          cf: {
+            space: 'foo',
+            environment: 'master',
+            field: 'title',
+            locale: 'agq',
+            entity: 'a1b2c3',
+            entityType: 'Entry',
+          },
         },
         spanishTitle: {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=es',
+          cf: {
+            space: 'foo',
+            environment: 'master',
+            field: 'title',
+            locale: 'es',
+            entity: 'a1b2c3',
+            entityType: 'Entry',
+          },
         },
       });
     });

--- a/packages/live-preview-sdk/src/__tests__/csm.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/csm.spec.ts
@@ -2,7 +2,7 @@ import { vercelStegaDecode } from '@vercel/stega';
 import { describe, test, expect } from 'vitest';
 
 import { encodeSourceMap } from '../csm';
-import { SourceMapMetadata } from '../csm/encode';
+import type { SourceMapMetadata } from '../csm/encode';
 
 type Mappings = Record<string, SourceMapMetadata | Record<string, SourceMapMetadata> | undefined>;
 

--- a/packages/live-preview-sdk/src/__tests__/csm.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/csm.spec.ts
@@ -77,7 +77,7 @@ describe('Content Source Maps', () => {
         title: {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
-          cf: {
+          contentful: {
             space: 'foo',
             environment: 'master',
             field: 'title',
@@ -89,7 +89,7 @@ describe('Content Source Maps', () => {
         subtitle: {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US',
-          cf: {
+          contentful: {
             space: 'foo',
             environment: 'master',
             field: 'subtitle',
@@ -145,7 +145,7 @@ describe('Content Source Maps', () => {
         title: {
           origin: 'contentful.com',
           href: 'https://app.eu.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
-          cf: {
+          contentful: {
             space: 'foo',
             environment: 'master',
             field: 'title',
@@ -157,7 +157,7 @@ describe('Content Source Maps', () => {
         subtitle: {
           origin: 'contentful.com',
           href: 'https://app.eu.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US',
-          cf: {
+          contentful: {
             space: 'foo',
             environment: 'master',
             field: 'subtitle',
@@ -231,7 +231,7 @@ describe('Content Source Maps', () => {
           title: {
             origin: 'contentful.com',
             href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
-            cf: {
+            contentful: {
               space: 'foo',
               environment: 'master',
               field: 'title',
@@ -245,7 +245,7 @@ describe('Content Source Maps', () => {
           title: {
             origin: 'contentful.com',
             href: 'https://app.contentful.com/spaces/foo/environments/master/entries/d4e5f6/?focusedField=title&focusedLocale=en-US',
-            cf: {
+            contentful: {
               space: 'foo',
               environment: 'master',
               field: 'title',
@@ -259,7 +259,7 @@ describe('Content Source Maps', () => {
           title: {
             origin: 'contentful.com',
             href: 'https://app.contentful.com/spaces/foo/environments/master/entries/g7h8i9/?focusedField=title&focusedLocale=en-US',
-            cf: {
+            contentful: {
               space: 'foo',
               environment: 'master',
               field: 'title',
@@ -325,7 +325,7 @@ describe('Content Source Maps', () => {
         akanTitle: {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=ak',
-          cf: {
+          contentful: {
             space: 'foo',
             environment: 'master',
             field: 'title',
@@ -337,7 +337,7 @@ describe('Content Source Maps', () => {
         aghemTitle: {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=agq',
-          cf: {
+          contentful: {
             space: 'foo',
             environment: 'master',
             field: 'title',
@@ -349,7 +349,7 @@ describe('Content Source Maps', () => {
         spanishTitle: {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=es',
-          cf: {
+          contentful: {
             space: 'foo',
             environment: 'master',
             field: 'title',

--- a/packages/live-preview-sdk/src/csm/encode.ts
+++ b/packages/live-preview-sdk/src/csm/encode.ts
@@ -3,7 +3,7 @@ import { vercelStegaDecode, vercelStegaEncode } from '@vercel/stega';
 export type SourceMapMetadata = {
   origin: string;
   href: string;
-  cf: {
+  contentful: {
     space: string;
     environment: string;
     entity: string;

--- a/packages/live-preview-sdk/src/csm/encode.ts
+++ b/packages/live-preview-sdk/src/csm/encode.ts
@@ -1,0 +1,22 @@
+import { vercelStegaDecode, vercelStegaEncode } from '@vercel/stega';
+
+export type SourceMapMetadata = {
+  origin: string;
+  href: string;
+  cf: {
+    space: string;
+    environment: string;
+    entity: string;
+    entityType: 'Entry' | 'Asset';
+    field: string;
+    locale: string;
+  };
+};
+
+export function encode(metadata: SourceMapMetadata): string {
+  return vercelStegaEncode(metadata);
+}
+
+export function decode(text: string): SourceMapMetadata | undefined {
+  return vercelStegaDecode(text);
+}

--- a/packages/live-preview-sdk/src/csm/index.ts
+++ b/packages/live-preview-sdk/src/csm/index.ts
@@ -22,7 +22,7 @@ const getHref = (
   field: string,
   locale: string,
   targetOrigin?: 'https://app.contentful.com' | 'https://app.eu.contentful.com'
-): string | null => {
+): string => {
   const targetOriginUrl = targetOrigin || 'https://app.contentful.com';
   const basePath = `${targetOriginUrl}/spaces/${space}/environments/${environment}`;
   const entityRoute = entityType === 'Entry' ? 'entries' : 'assets';
@@ -53,7 +53,7 @@ export const encodeSourceMap = (
     const entityType = 'entry' in source ? 'Entry' : 'Asset';
 
     if (!entity) {
-      graphqlResponse;
+      return graphqlResponse;
     }
 
     const space = spaces[entity.space];
@@ -64,14 +64,14 @@ export const encodeSourceMap = (
 
     const href = getHref(entityId, entityType, space, environment, field, locale, targetOrigin);
 
-    if (href && jsonPointer.has(data, pointer)) {
+    if (jsonPointer.has(data, pointer)) {
       const currentValue = jsonPointer.get(data, pointer);
 
       if (!isUrlOrIsoDate(currentValue)) {
         const encodedValue = encode({
           origin: 'contentful.com',
           href,
-          cf: {
+          contentful: {
             space,
             environment,
             field,

--- a/packages/live-preview-sdk/src/index.ts
+++ b/packages/live-preview-sdk/src/index.ts
@@ -50,6 +50,10 @@ export interface ContentfulLivePreviewInitConfig {
    * Can be `https://app.contentful.com` or `https://app.eu.contentful.com`
    */
   targetOrigin?: string | string[];
+
+  experimental?: {
+    ignoreManuallyTaggedElements?: boolean;
+  };
 }
 
 export interface ContentfulSubscribeConfig {
@@ -120,7 +124,11 @@ export class ContentfulLivePreview {
 
       // setup the live preview plugins (inspectorMode and liveUpdates)
       if (this.inspectorModeEnabled) {
-        this.inspectorMode = new InspectorMode({ locale, targetOrigin: this.targetOrigin });
+        this.inspectorMode = new InspectorMode({
+          locale,
+          targetOrigin: this.targetOrigin,
+          ignoreManuallyTaggedElements: config.experimental?.ignoreManuallyTaggedElements,
+        });
       }
 
       if (this.liveUpdatesEnabled) {

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
@@ -93,7 +93,7 @@ describe('getAllTaggedElements', () => {
     });
   });
 
-  describe.only('Auto-tagging', () => {
+  describe('Auto-tagging', () => {
     const encode = ({
       text,
       href,

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
@@ -97,7 +97,7 @@ describe('getAllTaggedElements', () => {
     const metadata: SourceMapMetadata = {
       href: 'contentful.com/test',
       origin: 'contentful.com',
-      cf: {
+      contentful: {
         space: 'test',
         environment: 'master',
         entity: 'entry-id',

--- a/packages/live-preview-sdk/src/inspectorMode/index.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/index.ts
@@ -5,7 +5,7 @@ import {
   type InspectorModeChangedMessage,
   InspectorModeEventMethods,
 } from './types';
-import { getAllTaggedElements, getAllTaggedEntries, getInspectorModeAttributes } from './utils';
+import { getAllTaggedElements, getInspectorModeAttributes } from './utils';
 
 type InspectorModeOptions = {
   locale: string;

--- a/packages/live-preview-sdk/src/inspectorMode/index.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/index.ts
@@ -5,11 +5,12 @@ import {
   type InspectorModeChangedMessage,
   InspectorModeEventMethods,
 } from './types';
-import { getAllTaggedElements, getInspectorModeAttributes } from './utils';
+import { getAllTaggedElements, getAllTaggedEntries, getInspectorModeAttributes } from './utils';
 
 type InspectorModeOptions = {
   locale: string;
   targetOrigin: string[];
+  ignoreManuallyTaggedElements?: boolean;
 };
 
 export class InspectorMode {

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -69,9 +69,9 @@ export function getAllTaggedElements(root = window.document, ignoreManual?: bool
     if (node.nodeType === Node.TEXT_NODE) {
       const text = node.textContent ?? '';
 
-      const { origin } = decode(text) ?? {};
+      const decoded = decode(text);
 
-      if (origin !== 'contentful.com') {
+      if (decoded?.origin !== 'contentful.com') {
         return NodeFilter.FILTER_SKIP;
       }
 
@@ -99,23 +99,32 @@ export function getAllTaggedElements(root = window.document, ignoreManual?: bool
       continue;
     }
 
+    if (!node.textContent) {
+      continue;
+    }
     // Handle Encoded strings
-    const { cf } = decode(node.textContent ?? '') as SourceMapMetadata;
+    const decoded = decode(node.textContent);
+
+    if (!decoded?.contentful) {
+      continue;
+    }
+
+    const { contentful } = decoded;
     const el = node.parentElement;
 
     if (!el) {
       continue;
     }
 
-    if (cf.entityType === 'Entry') {
-      el.setAttribute(InspectorModeDataAttributes.ENTRY_ID, cf.entity);
+    if (contentful.entityType === 'Entry') {
+      el.setAttribute(InspectorModeDataAttributes.ENTRY_ID, contentful.entity);
     } else {
-      el.setAttribute(InspectorModeDataAttributes.ASSET_ID, cf.entity);
+      el.setAttribute(InspectorModeDataAttributes.ASSET_ID, contentful.entity);
     }
 
     // TODO: add space/env ids to properly handle cross-space content
-    el.setAttribute(InspectorModeDataAttributes.LOCALE, cf.locale);
-    el.setAttribute(InspectorModeDataAttributes.FIELD_ID, cf.field);
+    el.setAttribute(InspectorModeDataAttributes.LOCALE, contentful.locale);
+    el.setAttribute(InspectorModeDataAttributes.FIELD_ID, contentful.field);
 
     elements.push(el);
   }

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -1,4 +1,4 @@
-import { decode, SourceMapMetadata } from '../csm/encode';
+import { decode } from '../csm/encode';
 import { InspectorModeAttributes, InspectorModeDataAttributes } from './types';
 
 const isTaggedElement = (node?: Node | null): boolean => {

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -104,7 +104,6 @@ export function getAllTaggedElements(root = window.document, ignoreManual?: bool
     const el = node.parentElement;
 
     if (!el) {
-      console.log('skipping no parent');
       continue;
     }
 
@@ -120,7 +119,6 @@ export function getAllTaggedElements(root = window.document, ignoreManual?: bool
     const localeCode = params.get('focusedLocale');
 
     if ((!entryId && !assetId) || !fieldId) {
-      console.log('skipping no entry id or asset id');
       continue;
     }
 


### PR DESCRIPTION
- Detect hidden strings in a page and convert it to proper data attributes.
  - Note that this doesn't care about whether a parent element is manually tagged or not.
- Adds a flag to ignore existing manual attributes for testing purposes.