### PR TITLE
chore: export CSM utils

### DIFF
--- a/packages/live-preview-sdk/src/__tests__/csm.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/csm.spec.ts
@@ -2,7 +2,7 @@ import { vercelStegaDecode } from '@vercel/stega';
 import jsonPointer from 'json-pointer';
 import { describe, test, expect } from 'vitest';
 
-import { encodeSourceMap } from '../csm';
+import { encodeGraphQLResponse } from '../csm';
 import type { SourceMapMetadata } from '../csm/encode';
 
 type Mappings = Record<string, SourceMapMetadata | Record<string, SourceMapMetadata> | undefined>;
@@ -73,7 +73,7 @@ describe('Content Source Maps', () => {
           },
         },
       };
-      const encodedGraphQLResponse = encodeSourceMap(graphQLResponse);
+      const encodedGraphQLResponse = encodeGraphQLResponse(graphQLResponse);
       testEncodingDecoding(encodedGraphQLResponse.data.post, {
         '/title': {
           origin: 'contentful.com',
@@ -138,7 +138,7 @@ describe('Content Source Maps', () => {
           },
         },
       };
-      const encodedGraphQLResponse = encodeSourceMap(graphQLResponse);
+      const encodedGraphQLResponse = encodeGraphQLResponse(graphQLResponse);
       expect(encodedGraphQLResponse.data.post.title).toBeNull();
       expect(encodedGraphQLResponse.data.post.subtitle).toBeNull();
     });
@@ -179,7 +179,7 @@ describe('Content Source Maps', () => {
           },
         },
       };
-      const encodedGraphQLResponse = encodeSourceMap(
+      const encodedGraphQLResponse = encodeGraphQLResponse(
         graphQLResponse,
         'https://app.eu.contentful.com',
       );
@@ -267,7 +267,7 @@ describe('Content Source Maps', () => {
           },
         },
       };
-      const encodedGraphQLResponse = encodeSourceMap(graphQLResponse);
+      const encodedGraphQLResponse = encodeGraphQLResponse(graphQLResponse);
       testEncodingDecoding(encodedGraphQLResponse.data.postCollection.items, {
         '/0': {
           title: {
@@ -362,7 +362,7 @@ describe('Content Source Maps', () => {
           },
         },
       };
-      const encodedGraphQLResponse = encodeSourceMap(graphQLResponse);
+      const encodedGraphQLResponse = encodeGraphQLResponse(graphQLResponse);
       testEncodingDecoding(encodedGraphQLResponse.data.postCollection.items[0], {
         '/akanTitle': {
           origin: 'contentful.com',
@@ -433,7 +433,7 @@ describe('Content Source Maps', () => {
           },
         },
       };
-      const encodedGraphQLResponse = encodeSourceMap(graphQLResponse);
+      const encodedGraphQLResponse = encodeGraphQLResponse(graphQLResponse);
       expect(encodedGraphQLResponse.data.post.rte).toBeNull();
     });
 
@@ -509,7 +509,7 @@ describe('Content Source Maps', () => {
           },
         },
       };
-      const encodedGraphQLResponse = encodeSourceMap(graphQLResponse);
+      const encodedGraphQLResponse = encodeGraphQLResponse(graphQLResponse);
       testEncodingDecoding(encodedGraphQLResponse.data.post, {
         '/rte/json/content/0/content/0/value': {
           origin: 'contentful.com',
@@ -572,7 +572,7 @@ describe('Content Source Maps', () => {
           },
         },
       };
-      const encodedGraphQLResponse = encodeSourceMap(graphQLResponse);
+      const encodedGraphQLResponse = encodeGraphQLResponse(graphQLResponse);
 
       testEncodingDecoding(encodedGraphQLResponse.data.post, {
         '/date': undefined,
@@ -607,7 +607,7 @@ describe('Content Source Maps', () => {
           },
         },
       };
-      const encodedGraphQLResponse = encodeSourceMap(graphQLResponse);
+      const encodedGraphQLResponse = encodeGraphQLResponse(graphQLResponse);
 
       testEncodingDecoding(encodedGraphQLResponse.data.post, {
         '/url': undefined,

--- a/packages/live-preview-sdk/src/csm/encodeSourceMap.ts
+++ b/packages/live-preview-sdk/src/csm/encodeSourceMap.ts
@@ -31,7 +31,7 @@ const getHref = (
   return `${basePath}/${entityRoute}/${entityId}/?focusedField=${field}&focusedLocale=${locale}`;
 };
 
-export const encodeSourceMap = (
+export const encodeGraphQLResponse = (
   originalGraphqlResponse: GraphQLResponse,
   targetOrigin?: 'https://app.contentful.com' | 'https://app.eu.contentful.com',
 ): GraphQLResponse => {

--- a/packages/live-preview-sdk/src/csm/index.ts
+++ b/packages/live-preview-sdk/src/csm/index.ts
@@ -1,1 +1,2 @@
 export * from './encodeSourceMap';
+export * from './encode';

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -32,7 +32,7 @@ const isTaggedElement = (node?: Node | null): boolean => {
  */
 export function getInspectorModeAttributes(
   element: Element,
-  fallbackLocale: string
+  fallbackLocale: string,
 ): InspectorModeAttributes | null {
   if (!isTaggedElement(element)) {
     return null;
@@ -61,16 +61,19 @@ export function getInspectorModeAttributes(
 export function getAllTaggedElements(root = window.document, ignoreManual?: boolean): Element[] {
   // The fastest way to look up & iterate over DOM. Ref:
   // https://stackoverflow.com/a/2579869
-  //
+  // Initialize a TreeWalker to traverse all nodes, using a filter function to determine which nodes to consider.
   // Terminology:
   // FILTER_SKIP: Skip the current node
   // FILTER_REJECT: Skip the current node and all its children
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_ALL, (node) => {
+    // If the node is a text node, decode its content.
     if (node.nodeType === Node.TEXT_NODE) {
       const text = node.textContent ?? '';
 
+      // Decode the text content to check for Inspector Mode CSM
       const decoded = decode(text);
 
+      // Skip the node if it does not have Inspector Mode CSM
       if (decoded?.origin !== 'contentful.com') {
         return NodeFilter.FILTER_SKIP;
       }
@@ -82,29 +85,36 @@ export function getAllTaggedElements(root = window.document, ignoreManual?: bool
         : NodeFilter.FILTER_ACCEPT;
     }
 
+    // For non-text nodes, if ignoreManual is true, skip manually tagged elements.
     if (ignoreManual) {
       return NodeFilter.FILTER_SKIP;
     }
 
+    // Accept the node if it is tagged according to the isTaggedElement function, else skip.
     return isTaggedElement(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
   });
 
   const elements: Element[] = [];
 
+  // Iterate over the nodes accepted by the TreeWalker.
   while (walker.nextNode()) {
     const node = walker.currentNode;
 
+    // Add element nodes directly to the elements array.
     if (node.nodeType === Node.ELEMENT_NODE) {
       elements.push(walker.currentNode as Element);
       continue;
     }
 
+    // Skip nodes without text content.
     if (!node.textContent) {
       continue;
     }
-    // Handle Encoded strings
+
+    // Decode the text content for further processing.
     const decoded = decode(node.textContent);
 
+    // Skip if the decoded CSM is not from Contentful.
     if (!decoded?.contentful) {
       continue;
     }
@@ -112,10 +122,12 @@ export function getAllTaggedElements(root = window.document, ignoreManual?: bool
     const { contentful } = decoded;
     const el = node.parentElement;
 
+    // Skip if the parent element does not exist.
     if (!el) {
       continue;
     }
 
+    // Set attributes on the element based on the decoded CSM data.
     if (contentful.entityType === 'Entry') {
       el.setAttribute(InspectorModeDataAttributes.ENTRY_ID, contentful.entity);
     } else {
@@ -126,6 +138,7 @@ export function getAllTaggedElements(root = window.document, ignoreManual?: bool
     el.setAttribute(InspectorModeDataAttributes.LOCALE, contentful.locale);
     el.setAttribute(InspectorModeDataAttributes.FIELD_ID, contentful.field);
 
+    // Add the element to the elements array after setting attributes.
     elements.push(el);
   }
 
@@ -140,7 +153,7 @@ export function getAllTaggedEntries(): string[] {
     ...new Set(
       getAllTaggedElements()
         .map((element) => element.getAttribute(InspectorModeDataAttributes.ENTRY_ID))
-        .filter(Boolean) as string[]
+        .filter(Boolean) as string[],
     ),
   ];
 }


### PR DESCRIPTION
- add comments to explain how `getAllTaggedElements` works. This code was confusing me a lot and I hope this could help in the future.
- renamed `encodeSourceMap` to `encodeGraphQLResponse`
- exported `encode` and `decode` since we need it in the webapp when making live updates with CSM