### PR TITLE
feat(inspectorMode): support tagging for cross space references []

### DIFF
--- a/packages/live-preview-sdk/src/__tests__/index.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/index.spec.ts
@@ -141,6 +141,30 @@ describe('ContentfulLivePreview', () => {
       });
     });
 
+    it('returns the expected props with all available props', () => {
+      const entryId = 'test-entry-id';
+      const fieldId = 'test-field-id';
+      const locale = 'test-locale';
+      const space = 'test-space';
+      const environment = 'test-environment';
+
+      const result = ContentfulLivePreview.getProps({
+        entryId,
+        fieldId,
+        locale,
+        space,
+        environment,
+      });
+
+      expect(result).toStrictEqual({
+        [InspectorModeDataAttributes.FIELD_ID]: fieldId,
+        [InspectorModeDataAttributes.ENTRY_ID]: entryId,
+        [InspectorModeDataAttributes.LOCALE]: locale,
+        [InspectorModeDataAttributes.SPACE]: space,
+        [InspectorModeDataAttributes.ENVIRONMENT]: environment,
+      });
+    });
+
     it('returns null if it is disabled', () => {
       ContentfulLivePreview.toggleInspectorMode();
 

--- a/packages/live-preview-sdk/src/__tests__/react.spec.tsx
+++ b/packages/live-preview-sdk/src/__tests__/react.spec.tsx
@@ -248,6 +248,38 @@ describe('useContentfulInspectorMode', () => {
       });
     });
 
+    it('should provide a helper function to generate the correct tags (with space & environment)', () => {
+      const { result } = renderHook((data) => useContentfulInspectorMode(data), {
+        initialProps: { entryId: '1' },
+        wrapper: ({ children }) => (
+          <ContentfulLivePreviewProvider locale={locale}>{children}</ContentfulLivePreviewProvider>
+        ),
+      });
+
+      expect(result.current({ fieldId: 'title', space: '12345', environment: 'develop' })).toEqual({
+        'data-contentful-entry-id': '1',
+        'data-contentful-field-id': 'title',
+        'data-contentful-space': '12345',
+        'data-contentful-environment': 'develop',
+      });
+    });
+
+    it('should provide a helper function to generate the correct tags (with initial space & environment)', () => {
+      const { result } = renderHook((data) => useContentfulInspectorMode(data), {
+        initialProps: { entryId: '1', space: '99999', environment: 'main' },
+        wrapper: ({ children }) => (
+          <ContentfulLivePreviewProvider locale={locale}>{children}</ContentfulLivePreviewProvider>
+        ),
+      });
+
+      expect(result.current({ fieldId: 'title' })).toEqual({
+        'data-contentful-entry-id': '1',
+        'data-contentful-field-id': 'title',
+        'data-contentful-space': '99999',
+        'data-contentful-environment': 'main',
+      });
+    });
+
     it('should return null because the inspector mode is disabled', () => {
       const { result } = renderHook((data) => useContentfulInspectorMode(data), {
         initialProps: { locale, entryId: '1' },

--- a/packages/live-preview-sdk/src/inspectorMode/index.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/index.ts
@@ -9,6 +9,8 @@ import { getAllTaggedElements, getInspectorModeAttributes } from './utils.js';
 
 type InspectorModeOptions = {
   locale: string;
+  space?: string;
+  environment?: string;
   targetOrigin: string[];
   ignoreManuallyTaggedElements?: boolean;
 };
@@ -121,6 +123,8 @@ export class InspectorMode {
         InspectorModeDataAttributes.ENTRY_ID,
         InspectorModeDataAttributes.FIELD_ID,
         InspectorModeDataAttributes.LOCALE,
+        InspectorModeDataAttributes.SPACE,
+        InspectorModeDataAttributes.ENVIRONMENT,
       ],
       childList: true,
       subtree: true,
@@ -166,8 +170,8 @@ export class InspectorMode {
    * and sends it then to the editor
    */
   private handleTaggedElement = (element: HTMLElement): boolean => {
-    const { targetOrigin, locale } = this.options;
-    const taggedInformation = getInspectorModeAttributes(element, locale);
+    const { targetOrigin, locale, space, environment } = this.options;
+    const taggedInformation = getInspectorModeAttributes(element, { locale, space, environment });
 
     if (!taggedInformation) {
       return false;
@@ -222,6 +226,8 @@ export class InspectorMode {
           InspectorModeDataAttributes.ENTRY_ID,
           InspectorModeDataAttributes.FIELD_ID,
           InspectorModeDataAttributes.LOCALE,
+          InspectorModeDataAttributes.SPACE,
+          InspectorModeDataAttributes.ENVIRONMENT,
         ],
         childList: true,
         subtree: true,

--- a/packages/live-preview-sdk/src/inspectorMode/types.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/types.ts
@@ -1,14 +1,17 @@
 import type { SetRequired } from 'type-fest';
 
-export type InspectorModeEntryTags = {
-  [InspectorModeDataAttributes.ENTRY_ID]: string;
+type InspectorModeSharedTags = {
   [InspectorModeDataAttributes.FIELD_ID]: string;
   [InspectorModeDataAttributes.LOCALE]?: string;
+  [InspectorModeDataAttributes.ENVIRONMENT]?: string;
+  [InspectorModeDataAttributes.SPACE]?: string;
 };
-export type InspectorModeAssetTags = {
+
+export type InspectorModeEntryTags = InspectorModeSharedTags & {
+  [InspectorModeDataAttributes.ENTRY_ID]: string;
+};
+export type InspectorModeAssetTags = InspectorModeSharedTags & {
   [InspectorModeDataAttributes.ASSET_ID]: string;
-  [InspectorModeDataAttributes.FIELD_ID]: string;
-  [InspectorModeDataAttributes.LOCALE]?: string;
 };
 export type InspectorModeTags = InspectorModeEntryTags | InspectorModeAssetTags | null;
 
@@ -17,6 +20,8 @@ export const enum InspectorModeDataAttributes {
   ENTRY_ID = 'data-contentful-entry-id',
   ASSET_ID = 'data-contentful-asset-id',
   LOCALE = 'data-contentful-locale',
+  SPACE = 'data-contentful-space',
+  ENVIRONMENT = 'data-contentful-environment',
 }
 
 export enum InspectorModeEventMethods {
@@ -29,15 +34,17 @@ export enum InspectorModeEventMethods {
   INSPECTOR_MODE_CHANGED = 'INSPECTOR_MODE_CHANGED',
 }
 
-export type InspectorModeEntryAttributes = {
-  entryId: string;
+type InspectorModeSharedAttributes = {
   fieldId: string;
   locale: string;
+  space?: string;
+  environment?: string;
 };
-export type InspectorModeAssetAttributes = {
+export type InspectorModeEntryAttributes = InspectorModeSharedAttributes & {
+  entryId: string;
+};
+export type InspectorModeAssetAttributes = InspectorModeSharedAttributes & {
   assetId: string;
-  fieldId: string;
-  locale: string;
 };
 
 export type InspectorModeAttributes = InspectorModeEntryAttributes | InspectorModeAssetAttributes;

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -38,24 +38,28 @@ const isTaggedElement = (node?: Node | null): boolean => {
  */
 export function getInspectorModeAttributes(
   element: Element,
-  fallbackLocale: string,
+  fallbackProps: Pick<InspectorModeAttributes, 'environment' | 'locale' | 'space'>,
 ): InspectorModeAttributes | null {
   if (!isTaggedElement(element)) {
     return null;
   }
 
-  const fieldId = element.getAttribute(InspectorModeDataAttributes.FIELD_ID) as string;
-  const locale = element.getAttribute(InspectorModeDataAttributes.LOCALE) ?? fallbackLocale;
+  const sharedProps = {
+    fieldId: element.getAttribute(InspectorModeDataAttributes.FIELD_ID) as string,
+    locale: element.getAttribute(InspectorModeDataAttributes.LOCALE) ?? fallbackProps.locale,
+    environment:
+      element.getAttribute(InspectorModeDataAttributes.ENVIRONMENT) ?? fallbackProps.environment,
+    space: element.getAttribute(InspectorModeDataAttributes.SPACE) ?? fallbackProps.space,
+  };
 
   const entryId = element.getAttribute(InspectorModeDataAttributes.ENTRY_ID);
-  const assetId = element.getAttribute(InspectorModeDataAttributes.ASSET_ID);
-
   if (entryId) {
-    return { entryId, fieldId, locale };
+    return { ...sharedProps, entryId };
   }
 
+  const assetId = element.getAttribute(InspectorModeDataAttributes.ASSET_ID);
   if (assetId) {
-    return { assetId, fieldId, locale };
+    return { ...sharedProps, assetId };
   }
 
   return null;
@@ -248,6 +252,8 @@ export function getAllTaggedElements(root = window.document, ignoreManual?: bool
     }
     element.setAttribute(InspectorModeDataAttributes.FIELD_ID, sourceMap.contentful.field);
     element.setAttribute(InspectorModeDataAttributes.LOCALE, sourceMap.contentful.locale);
+    element.setAttribute(InspectorModeDataAttributes.SPACE, sourceMap.contentful.space);
+    element.setAttribute(InspectorModeDataAttributes.ENVIRONMENT, sourceMap.contentful.environment);
     taggedElements.push(element);
   }
 

--- a/packages/live-preview-sdk/src/messages.ts
+++ b/packages/live-preview-sdk/src/messages.ts
@@ -11,6 +11,8 @@ import {
   type InspectorModeResizeMessage,
   type InspectorModeScrollMessage,
   type InspectorModeTaggedElementsMessage,
+  type InspectorModeEntryAttributes,
+  type InspectorModeAssetAttributes,
 } from './inspectorMode/types.js';
 import type { Argument, ContentType, EntityReferenceMap } from './types.js';
 
@@ -175,37 +177,29 @@ export type MessageFromEditor = (
 };
 
 export function openEntryInEditorUtility(
-  fieldId: string,
-  entryId: string,
-  locale: string,
+  props: InspectorModeEntryAttributes,
   targetOrigin: string[],
 ): void {
   sendMessageToEditor(
     LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED,
     {
       action: LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED,
-      fieldId,
-      entryId,
-      locale,
-    },
+      ...props,
+    } as TaggedFieldClickMessage,
     targetOrigin,
   );
 }
 
 export function openAssetInEditorUtility(
-  fieldId: string,
-  assetId: string,
-  locale: string,
+  props: InspectorModeAssetAttributes,
   targetOrigin: string[],
 ): void {
   sendMessageToEditor(
     LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED,
     {
       action: LivePreviewPostMessageMethods.TAGGED_FIELD_CLICKED,
-      fieldId,
-      assetId,
-      locale,
-    },
+      ...props,
+    } as TaggedFieldClickMessage,
     targetOrigin,
   );
 }

--- a/packages/live-preview-sdk/src/react.tsx
+++ b/packages/live-preview-sdk/src/react.tsx
@@ -58,6 +58,8 @@ const ContentfulLivePreviewContext = createContext<ContentfulLivePreviewInitConf
 export function ContentfulLivePreviewProvider({
   children,
   locale,
+  space,
+  environment,
   debugMode = false,
   enableInspectorMode = true,
   enableLiveUpdates = true,
@@ -72,6 +74,8 @@ export function ContentfulLivePreviewProvider({
 
   ContentfulLivePreview.init({
     locale,
+    space,
+    environment,
     debugMode,
     enableInspectorMode,
     enableLiveUpdates,
@@ -80,8 +84,16 @@ export function ContentfulLivePreviewProvider({
   });
 
   const props = useMemo(
-    () => ({ locale, debugMode, enableInspectorMode, enableLiveUpdates, targetOrigin }),
-    [locale, debugMode, enableInspectorMode, enableLiveUpdates, targetOrigin],
+    () => ({
+      locale,
+      space,
+      environment,
+      debugMode,
+      enableInspectorMode,
+      enableLiveUpdates,
+      targetOrigin,
+    }),
+    [locale, space, environment, debugMode, enableInspectorMode, enableLiveUpdates, targetOrigin],
   );
 
   return (
@@ -179,25 +191,28 @@ export function useContentfulLiveUpdates<T extends Argument | null | undefined>(
 }
 
 type GetInspectorModeProps<T> = (
-  props:
+  props: (
     | {
-        [K in Exclude<keyof LivePreviewEntryProps, keyof T | 'locale'>]: LivePreviewEntryProps[K];
+        [K in Exclude<
+          keyof LivePreviewEntryProps,
+          keyof T | 'locale' | 'environment' | 'space'
+        >]: LivePreviewEntryProps[K];
       }
-    | ({
-        [K in Exclude<keyof LivePreviewAssetProps, keyof T | 'locale'>]: LivePreviewAssetProps[K];
-      } & { locale?: LivePreviewProps['locale'] }),
+    | {
+        [K in Exclude<
+          keyof LivePreviewAssetProps,
+          keyof T | 'locale' | 'environment' | 'space'
+        >]: LivePreviewAssetProps[K];
+      }
+  ) &
+    Pick<LivePreviewProps, 'environment' | 'locale' | 'space'>,
 ) => InspectorModeTags;
 
 /**
  * Generates the function to build the required properties for the inspector mode (field tagging)
  */
 export function useContentfulInspectorMode<
-  T =
-    | undefined
-    | Pick<LivePreviewEntryProps, 'entryId'>
-    | Pick<LivePreviewEntryProps, 'entryId' | 'fieldId'>
-    | Pick<LivePreviewAssetProps, 'assetId'>
-    | Pick<LivePreviewAssetProps, 'assetId' | 'fieldId'>,
+  T = undefined | Partial<LivePreviewAssetProps> | Partial<LivePreviewEntryProps>,
 >(sharedProps?: T): GetInspectorModeProps<T> {
   const config = useContext(ContentfulLivePreviewContext);
 

--- a/packages/live-preview-sdk/src/types.ts
+++ b/packages/live-preview-sdk/src/types.ts
@@ -1,19 +1,24 @@
 import type { Asset, Entry } from 'contentful';
 import type { ContentTypeProps } from 'contentful-management';
 
+import type {
+  InspectorModeAssetAttributes,
+  InspectorModeEntryAttributes,
+} from './inspectorMode/types.js';
+
 export type ContentType = ContentTypeProps;
 export const ASSET_TYPENAME = 'Asset';
 
-export type LivePreviewEntryProps = {
-  fieldId: string;
-  entryId: string;
-  locale?: string;
-};
-export type LivePreviewAssetProps = {
-  fieldId: string;
-  assetId: string;
-  locale?: string;
-};
+type WithOptional<T, Keys extends keyof T> = Omit<T, Keys> & Partial<Pick<T, Keys>>;
+
+export type LivePreviewEntryProps = WithOptional<
+  InspectorModeEntryAttributes,
+  'locale' | 'environment' | 'space'
+>;
+export type LivePreviewAssetProps = WithOptional<
+  InspectorModeAssetAttributes,
+  'locale' | 'environment' | 'space'
+>;
 
 export type LivePreviewProps =
   | (LivePreviewEntryProps & { assetId?: never })


### PR DESCRIPTION
Add the ability to add space and environment for inspectorMode attributes.
For the CSM they are automatically picked up

Closes #526