### PR TITLE
fix(inspectorMode): img tagging with CSM []

### DIFF
--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
@@ -200,6 +200,35 @@ describe('getAllTaggedElements', () => {
       });
     });
 
+    it('should tag the images correctly by prefering the wrapping picture or figure', () => {
+      const img1 = createSourceMapFixture('img1', { contentful: { entityType: 'Asset' } });
+      const img2 = createSourceMapFixture('img2', { contentful: { entityType: 'Asset' } });
+      const img3 = createSourceMapFixture('img3', { contentful: { entityType: 'Asset' } });
+
+      const dom = html(`
+        <div>
+          <figure id="img1">
+            <img src="/elephant.jpg" alt="${combine('Elephant at sunset', img1)}" />
+            <figcaption>${combine('An elephant at sunset', img1)}</figcaption>
+          </figure>
+          <picture id="img2">
+            <source srcset="/lion-potrait.jpg" media="(orientation: portrait)" />
+            <img src="/lion-298-332.jpg" alt="${combine('A lion staring at the sun', img2)}" />
+          </picture>
+          <img id="img3" src="./monkey.jpg" alt="${combine('A monkey throwing a cocosnut at a lion', img3)}" />
+        </div>
+      `);
+
+      const elements = getAllTaggedElements(dom);
+
+      expect(elements).toHaveLength(3);
+      expect(elements).toEqual([
+        dom.getElementById('img1'),
+        dom.getElementById('img2'),
+        dom.getElementById('img3'),
+      ]);
+    });
+
     it('does not override elements that are manually tagged', () => {
       const dom = html(`<div>
 	    <div id="entry" ${dataEntry}="manual-entry-id" ${dataField}="manual-field-id">

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -190,7 +190,9 @@ export function getAllTaggedElements(root = window.document, ignoreManual?: bool
 
     // Tag img tags directly, no need for further checks
     if (isImg(node)) {
-      elementsForTagging.push({ element: node, sourceMap });
+      // check for parent `figure/picture` to add the tagging there, otherwise use the image directly
+      const element = node.closest('figure') || node.closest('picture') || node;
+      elementsForTagging.push({ element, sourceMap });
       continue;
     }
 


### PR DESCRIPTION
Optimize tagging for images with `<picture>` or `<figure>`