### PR TITLE
fix(content-source-maps): improve tracking for richtext []

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "lerna run lint",
     "tsc": "lerna run tsc",
     "test": "lerna run --stream test",
+    "benchmark": "lerna run benchmark",
     "test:ci": "lerna run test:ci",
     "coverage": "lerna run coverage",
     "version": "lerna version --no-private --conventional-commits --create-release github --yes --exact",

--- a/packages/live-preview-sdk/package.json
+++ b/packages/live-preview-sdk/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "start": "vite build --watch",
     "build": "vite build",
+    "benchmark": "vitest bench",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
     "tsc": "tsc --noEmit",
     "test": "vitest",

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/fixtures/contentSourceMap.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/fixtures/contentSourceMap.ts
@@ -1,0 +1,29 @@
+import type { SourceMapMetadata } from '@contentful/content-source-maps';
+
+export function createSourceMapFixture(
+  entityId: string,
+  overrides?: {
+    origin?: string;
+    contentful?: Partial<Omit<SourceMapMetadata['contentful'], 'entity'>>;
+  },
+): SourceMapMetadata {
+  const origin = overrides?.origin ?? 'contentful.com';
+  const space = overrides?.contentful?.space ?? 'master';
+  const environment = overrides?.contentful?.environment ?? 'master';
+  const entityType = overrides?.contentful?.entityType ?? 'Entry';
+  const locale = overrides?.contentful?.locale ?? 'en-US';
+  const field = overrides?.contentful?.field ?? 'title';
+
+  return {
+    href: `https://app.${origin}/spaces/${space}/environments/${environment}/entries/${entityId}?focusedField=${field}&focusedLocale=${locale}`,
+    origin,
+    contentful: {
+      space,
+      environment,
+      entity: entityId,
+      entityType,
+      field,
+      locale,
+    },
+  };
+}

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.bench.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.bench.ts
@@ -1,0 +1,96 @@
+import { combine } from '@contentful/content-source-maps';
+import { describe, expect, bench } from 'vitest';
+
+import { getAllTaggedElements } from '../utils.js';
+import { createSourceMapFixture } from './fixtures/contentSourceMap.js';
+
+describe('getAllTaggedElements', () => {
+  const html = (text: string) => {
+    return new DOMParser().parseFromString(text, 'text/html');
+  };
+
+  bench('should work performant on larger pages', () => {
+    const dom = html(`
+        <div id="root">
+          <div id="parent_tagged">
+            ${new Array(10)
+              .fill('x')
+              .map((_, index) => {
+                const sourceMap = createSourceMapFixture('parent_tagged');
+                const content = combine(
+                  `Parent should be tagged even if this is the "${index}" element.`,
+                  sourceMap,
+                );
+                return `<p>${content}</p>`;
+              })
+              .join('')}
+          </div>
+          <div id="flat_list">
+            ${new Array(10)
+              .fill('x')
+              .map((_, index) => {
+                const sourceMap = createSourceMapFixture(`flat_item-${index}`);
+                const content = combine(
+                  `Every item in the flat list should be tagged. This is the ${index} element.`,
+                  sourceMap,
+                );
+                return `<p>${content}</p>`;
+              })
+              .join('')}
+          </div>
+          <div id="richtext">
+            ${new Array(30)
+              .fill('x')
+              .map((_, index) => {
+                const sourceMap = createSourceMapFixture(`rte-nested-${index}`);
+                const inlineItems = new Array(10).fill('x').map((_, nestedIndex) => {
+                  const tag = nestedIndex % 2 === 0 ? 'strong' : 'b';
+                  const content = combine(
+                    `Richtext nested content with tag ${tag} ${index} ${nestedIndex}`,
+                    sourceMap,
+                  );
+                  return `<${tag}>${content}</${tag}>`;
+                });
+
+                const inlineContent = inlineItems.join(' ');
+
+                return `<p id="richtext-paragraph-${index}">${inlineContent}</p>`;
+              })
+              .join('\n')}
+          </div>
+          <div id="img">
+            <img
+              src="./picture.jpg"
+              alt="${combine('Some alt text for the picture', createSourceMapFixture('img-1', { contentful: { entityType: 'Asset' } }))}"
+            />
+          </div>
+          <div id="picture">
+            <picture>
+              <source srcset="/lion-potrait.jpg" media="(orientation: portrait)" />
+              <img
+                src="/lion-298-332.jpg"
+                alt="${combine('A lion staring at the sun', createSourceMapFixture('img-2', { contentful: { entityType: 'Asset' } }))}"
+              />
+            </picture>
+          </div>
+          <div id="figure">
+            <figure>
+              <span>
+                <span>
+                  <img
+                    src="/elephant.jpg"
+                    alt="${combine('Elephant at sunset', createSourceMapFixture('img-3', { contentful: { entityType: 'Asset' } }))})}"
+                  />
+                </span>
+              </span>
+              <figcaption>${combine('An elephant at sunset', createSourceMapFixture('img-3', { contentful: { entityType: 'Asset' } }))})}</figcaption>
+            </figure>
+          </div>
+        </div>
+      `);
+
+    const elements = getAllTaggedElements(dom, true);
+
+    expect(elements).toHaveLength(1 + 10 + 30 + 3);
+  });
+});

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
@@ -1,42 +1,15 @@
-import { SourceMapMetadata, combine } from '@contentful/content-source-maps';
+import { combine } from '@contentful/content-source-maps';
 import { describe, expect, it } from 'vitest';
 
 import { InspectorModeDataAttributes } from '../types.js';
 import { getAllTaggedElements } from '../utils.js';
+import { createSourceMapFixture } from './fixtures/contentSourceMap.js';
 
 describe('getAllTaggedElements', () => {
   const dataEntry = InspectorModeDataAttributes.ENTRY_ID;
   const dataAsset = InspectorModeDataAttributes.ASSET_ID;
   const dataField = InspectorModeDataAttributes.FIELD_ID;
   const dataLocale = InspectorModeDataAttributes.LOCALE;
-
-  function createSourceMapFixture(
-    entityId: string,
-    overrides?: {
-      origin?: string;
-      contentful?: Partial<Omit<SourceMapMetadata['contentful'], 'entity'>>;
-    },
-  ): SourceMapMetadata {
-    const origin = overrides?.origin ?? 'contentful.com';
-    const space = overrides?.contentful?.space ?? 'master';
-    const environment = overrides?.contentful?.environment ?? 'master';
-    const entityType = overrides?.contentful?.entityType ?? 'Entry';
-    const locale = overrides?.contentful?.locale ?? 'en-US';
-    const field = overrides?.contentful?.field ?? 'title';
-
-    return {
-      href: `https://app.${origin}/spaces/${space}/environments/${environment}/entries/${entityId}?focusedField=${field}&focusedLocale=${locale}`,
-      origin,
-      contentful: {
-        space,
-        environment,
-        entity: entityId,
-        entityType,
-        field,
-        locale,
-      },
-    };
-  }
 
   const html = (text: string) => {
     return new DOMParser().parseFromString(text, 'text/html');
@@ -279,94 +252,6 @@ describe('getAllTaggedElements', () => {
       );
       expect(elements[0].getAttribute(InspectorModeDataAttributes.FIELD_ID)).toEqual('title');
       expect(elements[0].getAttribute(InspectorModeDataAttributes.LOCALE)).toEqual('en-US');
-    });
-
-    it('works performant on larger pages', () => {
-      const dom = html(`
-      <div id="root">
-        <div id="parent_tagged">
-          ${new Array(10)
-            .fill('x')
-            .map((_, index) => {
-              const sourceMap = createSourceMapFixture('parent_tagged');
-              const content = combine(
-                `Parent should be tagged even if this is the "${index}" element.`,
-                sourceMap,
-              );
-              return `<p>${content}</p>`;
-            })
-            .join('')}
-        </div>
-        <div id="flat_list">
-          ${new Array(10)
-            .fill('x')
-            .map((_, index) => {
-              const sourceMap = createSourceMapFixture(`flat_item-${index}`);
-              const content = combine(
-                `Every item in the flat list should be tagged. This is the ${index} element.`,
-                sourceMap,
-              );
-              return `<p>${content}</p>`;
-            })
-            .join('')}
-        </div>
-        <div id="richtext">
-          ${new Array(30)
-            .fill('x')
-            .map((_, index) => {
-              const sourceMap = createSourceMapFixture(`rte-nested-${index}`);
-              const inlineItems = new Array(10).fill('x').map((_, nestedIndex) => {
-                const tag = nestedIndex % 2 === 0 ? 'strong' : 'b';
-                const content = combine(
-                  `Richtext nested content with tag ${tag} ${index} ${nestedIndex}`,
-                  sourceMap,
-                );
-                return `<${tag}>${content}</${tag}>`;
-              });
-
-              const inlineContent = inlineItems.join(' ');
-
-              return `<p id="richtext-paragraph-${index}">${inlineContent}</p>`;
-            })
-            .join('\n')}
-        </div>
-        <div id="img">
-          <img
-            src="./picture.jpg"
-            alt="${combine('Some alt text for the picture', createSourceMapFixture('img-1', { contentful: { entityType: 'Asset' } }))}"
-          />
-        </div>
-        <div id="picture">
-          <picture>
-            <source srcset="/lion-potrait.jpg" media="(orientation: portrait)" />
-            <img
-              src="/lion-298-332.jpg"
-              alt="${combine('A lion staring at the sun', createSourceMapFixture('img-2', { contentful: { entityType: 'Asset' } }))}"
-            />
-          </picture>
-        </div>
-        <div id="figure">
-          <figure>
-            <span>
-              <span>
-                <img
-                  src="/elephant.jpg"
-                  alt="${combine('Elephant at sunset', createSourceMapFixture('img-3', { contentful: { entityType: 'Asset' } }))})}"
-                />
-              </span>
-            </span>
-            <figcaption>${combine('An elephant at sunset', createSourceMapFixture('img-3', { contentful: { entityType: 'Asset' } }))})}</figcaption>
-          </figure>
-        </div>
-      </div>
-    `);
-
-      const starTime = performance.now();
-      const elements = getAllTaggedElements(dom, true);
-      const diff = performance.now() - starTime;
-
-      expect(elements).toHaveLength(1 + 10 + 30 + 3);
-      expect(diff).toBeLessThanOrEqual(100);
     });
   });
 });

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -1,4 +1,5 @@
 import { decode, type SourceMapMetadata } from '@contentful/content-source-maps';
+import { VERCEL_STEGA_REGEX } from '@vercel/stega';
 
 import { InspectorModeAttributes, InspectorModeDataAttributes } from './types.js';
 
@@ -65,45 +66,6 @@ export function getInspectorModeAttributes(
   return null;
 }
 
-function createSelector(key: InspectorModeDataAttributes, value: string) {
-  return `[${key}="${value}"]`;
-}
-
-function hasTaggedParent(element: Element | null, sourceMap: SourceMapMetadata) {
-  const selector = [
-    createSelector(
-      sourceMap.contentful.entityType === 'Asset'
-        ? InspectorModeDataAttributes.ASSET_ID
-        : InspectorModeDataAttributes.ENTRY_ID,
-      sourceMap.contentful.entity,
-    ),
-    createSelector(InspectorModeDataAttributes.FIELD_ID, sourceMap.contentful.field),
-    createSelector(InspectorModeDataAttributes.LOCALE, sourceMap.contentful.locale),
-  ].join('');
-
-  return element?.closest(selector);
-}
-
-function isImg(node: Node): node is HTMLImageElement {
-  return node.nodeName === 'IMG';
-}
-
-/**
- * Parses the content of the node
- * For the `img` element use the information from `alt` otherwise use the `textContent`
- */
-function getSourceMap(node: Node): SourceMapMetadata | null | undefined {
-  if (isImg(node)) {
-    return decode(node.alt);
-  }
-
-  if (node.nodeType === Node.TEXT_NODE) {
-    return decode(node.textContent || '');
-  }
-
-  return null;
-}
-
 /**
  * Check if both sourcemaps are identical
  * Based on how they're generated it's enough to check the URL
@@ -126,9 +88,6 @@ function isSameElement(a: AutoTaggedElement, b: AutoTaggedElement): boolean {
 
   return true;
 }
-
-/** Some elements don't makes sense to be tagged as they're not visible */
-const IGNORE_TAGS = ['SCRIPT', 'HEAD'];
 
 function getParent(
   child: Element,
@@ -174,84 +133,68 @@ function getParent(
   return null;
 }
 
+function findStegaNodes(container: HTMLElement) {
+  let baseArray: HTMLElement[] = [];
+  if (typeof container.matches === 'function' && container.matches('*')) {
+    baseArray = [container];
+  }
+
+  return [
+    ...baseArray,
+    ...Array.from(container.querySelectorAll<HTMLElement>('*:not(script,style,meta,title)')),
+  ]
+    .map((node) => ({ node, text: getNodeText(node) }))
+    .filter(({ text }) => !!(text && text.match(VERCEL_STEGA_REGEX)));
+}
+
+function getNodeText(node: HTMLElement): string {
+  if (node.matches('input[type=submit], input[type=button], input[type=reset]')) {
+    return (node as HTMLInputElement).value;
+  }
+
+  if (node.matches('img, video')) {
+    return (node as HTMLImageElement).alt;
+  }
+
+  return Array.from(node.childNodes)
+    .filter((child) => child.nodeType === Node.TEXT_NODE && Boolean(child.textContent))
+    .map((c) => c.textContent)
+    .join('');
+}
+
+function hasTaggedParent(node: HTMLElement, taggedElements: Element[]): boolean {
+  for (const tagged of taggedElements) {
+    if (tagged === node || tagged.contains(node)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Query the document for all tagged elements
  */
 export function getAllTaggedElements(root = window.document, ignoreManual?: boolean): Element[] {
-  // The fastest way to look up & iterate over DOM. Ref:
-  // https://stackoverflow.com/a/2579869
-  // Initialize a TreeWalker to traverse all nodes, using a filter function to determine which nodes to consider.
-  // Terminology:
-  // FILTER_SKIP: Skip the current node
-  // FILTER_REJECT: Skip the current node and all its children
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ALL, (node) => {
-    // Ignore tags that are not visible on the page
-    if (
-      node.nodeType === Node.ELEMENT_NODE &&
-      IGNORE_TAGS.includes((node as HTMLElement).tagName)
-    ) {
-      return NodeFilter.FILTER_REJECT;
-    }
+  const manualTagged = ignoreManual
+    ? []
+    : root.querySelectorAll(
+        `[${InspectorModeDataAttributes.ASSET_ID}][${InspectorModeDataAttributes.FIELD_ID}], [${InspectorModeDataAttributes.ENTRY_ID}][${InspectorModeDataAttributes.FIELD_ID}]`,
+      );
 
-    // Detect auto-tagged nodes
-    const sourceMap = getSourceMap(node);
-    if (sourceMap?.origin === 'contentful.com') {
-      // Ignore if the parent is already tagged with the same information
-      if (
-        (isTaggedElement(node.parentElement) || hasTaggedParent(node.parentElement, sourceMap)) &&
-        !ignoreManual
-      ) {
-        return NodeFilter.FILTER_SKIP;
-      }
-      return NodeFilter.FILTER_ACCEPT;
-    }
-
-    // For non-text nodes, if ignoreManual is true, skip manually tagged elements.
-    if (ignoreManual) {
-      return NodeFilter.FILTER_SKIP;
-    }
-
-    // Accept the node if it is tagged according to the isTaggedElement function, else skip.
-    return isTaggedElement(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
-  });
-
-  const taggedElements: Element[] = [];
+  const taggedElements: Element[] = [...manualTagged];
   const elementsForTagging: AutoTaggedElement<Element>[] = [];
 
-  // Iterate over the nodes accepted by the TreeWalker.
-  while (walker.nextNode()) {
-    const node = walker.currentNode;
+  const stegaNodes = findStegaNodes('body' in root ? root.body : root);
 
-    // Add already tagged element nodes directly to the elements array.
-    if (isTaggedElement(node)) {
-      taggedElements.push(walker.currentNode as Element);
+  for (const { node, text } of stegaNodes) {
+    const sourceMap = decode(text);
+    if (!sourceMap || !sourceMap.origin.includes('contentful.com')) {
       continue;
     }
 
-    // Decode the text content for further processing.
-    const sourceMap = getSourceMap(node);
-
-    // Skip if the decoded CSM is not from Contentful.
-    if (!sourceMap?.contentful) {
-      continue;
-    }
-
-    // Tag img tags directly, no need for further checks
-    if (isImg(node)) {
-      // check for parent `figure/picture` to add the tagging there, otherwise use the image directly
-      const element = node.closest('figure') || node.closest('picture') || node;
-      elementsForTagging.push({ element, sourceMap });
-      continue;
-    }
-
-    // Skip if the parent element does not exist.
-    const el = node.parentElement;
-    if (!el) {
-      continue;
-    }
-
-    // Skip if the parent is already selected for tagging with the same information
     if (
+      hasTaggedParent(node, taggedElements) ||
       elementsForTagging.some(
         (et) => et.element.contains(node) && isSameSourceMap(et.sourceMap, sourceMap),
       )
@@ -259,16 +202,20 @@ export function getAllTaggedElements(root = window.document, ignoreManual?: bool
       continue;
     }
 
-    // Check if the sibling text nodes have the same information, if yes apply it on their wrapper element
-    // TODO: perf improvement: if the csm contains the type information, we could do this only for rich-text
-    const wrapper = getParent(el, sourceMap);
-    if (wrapper) {
-      elementsForTagging.push({ element: wrapper.element, sourceMap: sourceMap });
+    if (node.matches('img')) {
+      const element = node.closest('figure') || node.closest('picture') || node;
+      elementsForTagging.push({ element, sourceMap });
       continue;
     }
 
-    // No sibling element with the same information, add the element directly
-    elementsForTagging.push({ element: el, sourceMap: sourceMap });
+    // TODO: Performance optimisation: only do for richtext
+    const wrapper = getParent(node, sourceMap);
+    if (wrapper) {
+      elementsForTagging.push({ element: wrapper.element, sourceMap: sourceMap });
+    } else {
+      // No sibling element with the same information, add the element directly
+      elementsForTagging.push({ element: node, sourceMap: sourceMap });
+    }
   }
 
   // Filter duplicate elements, so we don't tag them again and again


### PR DESCRIPTION
- Handle richtext correctly if all content is deeper nested
- Improve performance of content-source-map detection

**Before:**
![Screenshot 2024-02-26 at 12 04 24](https://github.com/contentful/live-preview/assets/3918488/deade44a-9909-4b55-aad2-76dcd2198ef3)

**Now:**
![Screenshot 2024-02-26 at 12 04 56](https://github.com/contentful/live-preview/assets/3918488/7f2b8781-fd69-4baf-b3a3-cd8c568f6dc6)

Will create a ticket to compare the benchmarks on CI, would be nice to have this feedback (or at least failing)
