### PR TITLE
feat: support editor interface and field types for CSM [TOL-1836]

### DIFF
--- a/packages/content-source-maps/src/encode.ts
+++ b/packages/content-source-maps/src/encode.ts
@@ -15,6 +15,11 @@ export type SourceMapMetadata = {
     entityType: string;
     field: string;
     locale: string;
+    editorInterface: {
+      widgetNamespace: string;
+      widgetId: string;
+    };
+    fieldType: string;
   };
 };
 

--- a/packages/content-source-maps/src/richText.ts
+++ b/packages/content-source-maps/src/richText.ts
@@ -3,9 +3,6 @@ import jsonPointer from 'json-pointer';
 import { SourceMapMetadata, combine } from './encode.js';
 import { Mappings } from './types.js';
 
-export const isRichTextValue = (value: unknown): boolean =>
-  !!(value && typeof value === 'object' && 'nodeType' in value && value.nodeType);
-
 export const encodeRichTextValue = ({
   pointer,
   mappings,

--- a/packages/content-source-maps/src/types.ts
+++ b/packages/content-source-maps/src/types.ts
@@ -1,6 +1,8 @@
 export type Source = {
   field: number;
   locale: number;
+  fieldType: number;
+  editorInterface: number;
 } & ({ entry: number } | { asset: number });
 
 export interface EntitySource {
@@ -11,10 +13,53 @@ export interface EntitySource {
 
 export type Mappings = Record<string, { source: Source }>;
 
+type FieldType = 'Symbol' | 'Text' | 'RichText' | 'Array';
+
+export type WidgetId =
+  | 'multipleLine'
+  | 'boolean'
+  | 'objectEditor'
+  | 'datePicker'
+  | 'locationEditor'
+  | 'checkbox'
+  | 'listInput'
+  | 'rating'
+  | 'radio'
+  | 'tagEditor'
+  | 'numberEditor'
+  | 'urlEditor'
+  | 'slugEditor'
+  | 'singleLine'
+  | 'dropdown'
+  | 'entryLinkEditor'
+  | 'entryCardEditor'
+  | 'entryLinksEditor'
+  | 'entryCardsEditor'
+  | 'assetLinkEditor'
+  | 'assetLinksEditor'
+  | 'assetGalleryEditor'
+  | 'richTextEditor'
+  | 'markdown'
+  | string; //Custom Contentful field app
+
+export type WidgetNamespace =
+  | 'builtin'
+  | 'extension'
+  | 'sidebar-builtin'
+  | 'app'
+  | 'editor-builtin';
+
+interface EditorInterfaceSource {
+  widgetId: WidgetId;
+  widgetNamespace: WidgetNamespace;
+}
+
 interface ContentSourceMaps {
   version: number;
   spaces: string[];
   environments: string[];
+  fieldTypes: FieldType[];
+  editorInterfaces: EditorInterfaceSource[];
   fields: string[];
   locales: string[];
   entries: EntitySource[];

--- a/packages/content-source-maps/src/utils.ts
+++ b/packages/content-source-maps/src/utils.ts
@@ -1,3 +1,5 @@
+import { WidgetId } from './types.js';
+
 /**
  * Clones the incoming element into a new one, to prevent modification on the original object
  * Hint: It uses the structuredClone which is only available in modern browsers,
@@ -15,3 +17,13 @@ export function clone<T extends Record<string, unknown> | Array<unknown>>(incomi
     return incoming;
   }
 }
+
+export const SUPPORTED_WIDGETS: WidgetId[] = [
+  'singleLine',
+  'tagEditor',
+  'listInput',
+  'checkbox',
+  'richTextEditor',
+  'multipleLine',
+  'markdown',
+];

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/fixtures/contentSourceMap.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/fixtures/contentSourceMap.ts
@@ -13,6 +13,11 @@ export function createSourceMapFixture(
   const entityType = overrides?.contentful?.entityType ?? 'Entry';
   const locale = overrides?.contentful?.locale ?? 'en-US';
   const field = overrides?.contentful?.field ?? 'title';
+  const editorInterface = overrides?.contentful?.editorInterface ?? {
+    widgetNamespace: 'builtin',
+    widgetId: 'singleLine',
+  };
+  const fieldType = overrides?.contentful?.fieldType ?? 'Symbol';
 
   return {
     href: `https://app.${origin}/spaces/${space}/environments/${environment}/entries/${entityId}?focusedField=${field}&focusedLocale=${locale}`,
@@ -24,6 +29,8 @@ export function createSourceMapFixture(
       entityType,
       field,
       locale,
+      editorInterface,
+      fieldType,
     },
   };
 }


### PR DESCRIPTION
## Description
The editor interface / field appearance of a field should determine if we generate hidden strings from the CSM for that field.

We return the editor interface as part of the CSM API GraphQL response and now have to filter it out in the SDK. This could enable future configuration for the user on the frontend side (e.g. they do want to add hidden strings to dropdown).

## Rules
- For symbol fields only create hidden strings in the SDK for the single line editor interface
- For short text list fields, we create hidden strings for all of them:
- For Rich text we always generate hidden strings
- For long text we generate hidden strings for single line, multiple line and markdown

## Todo
- [x] Before merging, we need to wait until the API side of things is done