### PR TITLE
feat: localhost allowed origin

### DIFF
--- a/packages/live-preview-sdk/src/index.ts
+++ b/packages/live-preview-sdk/src/index.ts
@@ -37,7 +37,11 @@ export type { LivePreviewAssetProps, LivePreviewEntryProps, LivePreviewProps };
 
 export const VERSION = version;
 
-const DEFAULT_ORIGINS = ['https://app.contentful.com', 'https://app.eu.contentful.com'];
+const DEFAULT_ORIGINS = [
+  'https://app.contentful.com',
+  'https://app.eu.contentful.com',
+  'http://localhost:3001', // for local debugging for Contentful engineers
+];
 
 export interface ContentfulLivePreviewInitConfig {
   locale: string;


### PR DESCRIPTION
When debugging customers issues we run the webapp locally. We need to allow the targetOrigin to be localhost otherwise live preview will not function.