### PR TITLE
fix: refreshing page instead of redirect []

### DIFF
--- a/examples/next-14-app-router-ssr/app/api/revalidate/route.ts
+++ b/examples/next-14-app-router-ssr/app/api/revalidate/route.ts
@@ -12,9 +12,9 @@ function getQSParamFromURL(key: string, url: string): string | null {
 export async function GET(request: Request) {
   // Parse query string parameters
   const path = getQSParamFromURL('pathname', request.url);
+  console.log({ path });
   if (path) {
     revalidatePath(path);
-    redirect(path);
   }
   return new Response('OK');
 }

--- a/examples/next-14-app-router-ssr/app/api/revalidate/route.ts
+++ b/examples/next-14-app-router-ssr/app/api/revalidate/route.ts
@@ -12,7 +12,7 @@ function getQSParamFromURL(key: string, url: string): string | null {
 export async function GET(request: Request) {
   // Parse query string parameters
   const path = getQSParamFromURL('pathname', request.url);
-  console.log({ path });
+
   if (path) {
     revalidatePath(path);
   }

--- a/examples/next-14-app-router-ssr/app/api/revalidate/route.ts
+++ b/examples/next-14-app-router-ssr/app/api/revalidate/route.ts
@@ -1,6 +1,5 @@
 // route handler with secret and slug
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
 
 function getQSParamFromURL(key: string, url: string): string | null {
   if (!url) return '';

--- a/examples/next-14-app-router-ssr/public/_live-preview.ts
+++ b/examples/next-14-app-router-ssr/public/_live-preview.ts
@@ -9,7 +9,7 @@ ContentfulLivePreview.init({
 ContentfulLivePreview.subscribe('save', {
   callback: async () => {
     const pathname = window.location.pathname;
-
-    return fetch(`/api/revalidate?pathname=${pathname}`);
+    await fetch(`/api/revalidate?pathname=${pathname}`);
+    window.location.reload();
   },
 });


### PR DESCRIPTION
Refreshing window instead of calling redirect

Redirect doesn't appear to work here, and I don't believe refreshing the page is that bad.

Maybe this is relevant: https://github.com/vercel/next.js/issues/59489