### PR TITLE
feat: remove encode from cpa export

### DIFF
--- a/packages/live-preview-sdk/src/index.ts
+++ b/packages/live-preview-sdk/src/index.ts
@@ -1,8 +1,4 @@
-import {
-  encodeGraphQLResponse,
-  encodeCPAResponse,
-  splitEncoding,
-} from '@contentful/content-source-maps';
+import { encodeGraphQLResponse, splitEncoding } from '@contentful/content-source-maps';
 import { type DocumentNode } from 'graphql';
 
 import { version } from '../package.json';
@@ -365,4 +361,4 @@ export class ContentfulLivePreview {
 export { LIVE_PREVIEW_EDITOR_SOURCE, LIVE_PREVIEW_SDK_SOURCE } from './constants.js';
 
 export * from './messages.js';
-export { encodeGraphQLResponse, encodeCPAResponse, splitEncoding };
+export { encodeGraphQLResponse, splitEncoding };


### PR DESCRIPTION
as part of [this](https://contentful.atlassian.net/browse/TOL-2080?atlOrigin=eyJpIjoiZjIyOWNkYmEwZGE5NDIyYTlhZmE4YTBjZTc2MDQwOWUiLCJwIjoiaiJ9) we are now removing the encodeCPAResponse export from the LP SDK