### PR TITLE
feat: export cpa response

### DIFF
--- a/packages/live-preview-sdk/src/index.ts
+++ b/packages/live-preview-sdk/src/index.ts
@@ -1,4 +1,8 @@
-import { encodeGraphQLResponse, splitEncoding } from '@contentful/content-source-maps';
+import {
+  encodeGraphQLResponse,
+  encodeCPAResponse,
+  splitEncoding,
+} from '@contentful/content-source-maps';
 import { type DocumentNode } from 'graphql';
 
 import { version } from '../package.json';
@@ -370,4 +374,4 @@ export class ContentfulLivePreview {
 export { LIVE_PREVIEW_EDITOR_SOURCE, LIVE_PREVIEW_SDK_SOURCE } from './constants.js';
 
 export * from './messages.js';
-export { encodeGraphQLResponse, splitEncoding };
+export { encodeGraphQLResponse, encodeCPAResponse, splitEncoding };


### PR DESCRIPTION
Re-exporting `encodeCPAResponse` for customers hitting the CPA directly (instead of using the JS Client SDK) and wanting to use encoding.