### PR TITLE
docs: update examples sdk version [TOL-2193]

### DIFF
--- a/examples/content-source-maps-cpa/package.json
+++ b/examples/content-source-maps-cpa/package.json
@@ -9,11 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@contentful/live-preview": "^3.3.7",
+    "@contentful/live-preview": "^4.2.2",
     "@types/node": "20.2.3",
     "@types/react": "18.2.7",
     "@types/react-dom": "18.2.4",
-    "contentful": "^10.11.7",
+    "contentful": "^10.12.0",
     "next": "14.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/examples/content-source-maps-graphql/package.json
+++ b/examples/content-source-maps-graphql/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@contentful/live-preview": "^3.3.4",
+    "@contentful/live-preview": "^4.2.2",
     "@types/node": "20.2.3",
     "@types/react": "18.2.7",
     "@types/react-dom": "18.2.4",


### PR DESCRIPTION
Updating to the latest SDK version so we can support the new Content Source Maps format coming from the API in the examples