### PR TITLE
chore: add ci alerts []

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,6 +8,7 @@ metadata:
     circleci.com/project-slug: github/contentful/live-preview
     github.com/project-slug: contentful/live-preview
     backstage.io/source-location: url:https://github.com/contentful/live-preview/
+    contentful.com/ci-alert-slack: prd-creators-tolkien-alerts
 spec:
   type: library
   lifecycle: production


### PR DESCRIPTION
thought it would be better directed here than to the default channel

https://contentful.slack.com/archives/C04LSEF4R2R/p1718964303895699
