### PR TITLE
feat(content-source-maps): allow specify a platform to reduce the payload []

### DIFF
--- a/packages/content-source-maps/src/__tests__/graphql.spec.ts
+++ b/packages/content-source-maps/src/__tests__/graphql.spec.ts
@@ -880,6 +880,156 @@ describe('Content Source Maps with the GraphQL API', () => {
     });
   });
 
+  test('adds only the `href` parameter in the encoding if platform `vercel` is configured', () => {
+    const graphQLResponse: GraphQLResponse = {
+      data: {
+        post: {
+          title: 'Title of the post',
+          subtitle: 'Subtitle of the post',
+        },
+      },
+      extensions: {
+        contentSourceMaps: {
+          spaces: ['foo'],
+          environments: ['master'],
+          fieldTypes: ['Symbol'],
+          editorInterfaces: [
+            {
+              widgetId: 'singleLine',
+              widgetNamespace: 'builtin',
+            },
+          ],
+          fields: ['title', 'subtitle'],
+          locales: ['en-US'],
+          entries: [{ space: 0, environment: 0, id: 'a1b2c3' }],
+          assets: [],
+          mappings: {
+            '/data/post/title': {
+              source: {
+                entry: 0,
+                field: 0,
+                locale: 0,
+                fieldType: 0,
+                editorInterface: 0,
+              },
+            },
+            '/data/post/subtitle': {
+              source: {
+                entry: 0,
+                field: 1,
+                locale: 0,
+                fieldType: 0,
+                editorInterface: 0,
+              },
+            },
+          },
+        },
+      },
+    };
+    const encodedGraphQLResponse = encodeGraphQLResponse(
+      graphQLResponse,
+      'https://app.contentful.com',
+      'vercel',
+    );
+    testEncodingDecoding(encodedGraphQLResponse.data.post, {
+      '/title': {
+        origin: 'contentful.com',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
+      },
+      '/subtitle': {
+        origin: 'contentful.com',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US',
+      },
+    });
+  });
+
+  test('adds only the `contentful` parameter in the encoding if platform `contentful` is configured', () => {
+    const graphQLResponse: GraphQLResponse = {
+      data: {
+        post: {
+          title: 'Title of the post',
+          subtitle: 'Subtitle of the post',
+        },
+      },
+      extensions: {
+        contentSourceMaps: {
+          spaces: ['foo'],
+          environments: ['master'],
+          fieldTypes: ['Symbol'],
+          editorInterfaces: [
+            {
+              widgetId: 'singleLine',
+              widgetNamespace: 'builtin',
+            },
+          ],
+          fields: ['title', 'subtitle'],
+          locales: ['en-US'],
+          entries: [{ space: 0, environment: 0, id: 'a1b2c3' }],
+          assets: [],
+          mappings: {
+            '/data/post/title': {
+              source: {
+                entry: 0,
+                field: 0,
+                locale: 0,
+                fieldType: 0,
+                editorInterface: 0,
+              },
+            },
+            '/data/post/subtitle': {
+              source: {
+                entry: 0,
+                field: 1,
+                locale: 0,
+                fieldType: 0,
+                editorInterface: 0,
+              },
+            },
+          },
+        },
+      },
+    };
+    const encodedGraphQLResponse = encodeGraphQLResponse(
+      graphQLResponse,
+      'https://app.contentful.com',
+      'contentful',
+    );
+    testEncodingDecoding(encodedGraphQLResponse.data.post, {
+      '/title': {
+        origin: 'contentful.com',
+        contentful: {
+          space: 'foo',
+          environment: 'master',
+          field: 'title',
+          locale: 'en-US',
+          entity: 'a1b2c3',
+          entityType: 'Entry',
+          editorInterface: {
+            widgetId: 'singleLine',
+            widgetNamespace: 'builtin',
+          },
+          fieldType: 'Symbol',
+        },
+      },
+      '/subtitle': {
+        origin: 'contentful.com',
+        contentful: {
+          space: 'foo',
+          environment: 'master',
+          field: 'subtitle',
+          locale: 'en-US',
+          entity: 'a1b2c3',
+          entityType: 'Entry',
+          editorInterface: {
+            widgetId: 'singleLine',
+            widgetNamespace: 'builtin',
+          },
+          fieldType: 'Symbol',
+        },
+      },
+    });
+  });
+
   describe('editor interfaces', () => {
     UNSUPPORTED_WIDGETS.forEach((widget) => {
       test(`does not encode ${widget}`, () => {

--- a/packages/content-source-maps/src/graphql/encodeGraphQLResponse.ts
+++ b/packages/content-source-maps/src/graphql/encodeGraphQLResponse.ts
@@ -1,6 +1,6 @@
 import { get, has } from 'json-pointer';
 
-import type { GraphQLResponse } from '../types.js';
+import type { CreateSourceMapParams, GraphQLResponse } from '../types.js';
 import {
   clone,
   createSourceMapMetadata,
@@ -11,7 +11,8 @@ import {
 
 export const encodeGraphQLResponse = (
   originalGraphqlResponse: GraphQLResponse,
-  targetOrigin?: 'https://app.contentful.com' | 'https://app.eu.contentful.com',
+  targetOrigin?: CreateSourceMapParams['targetOrigin'],
+  platform?: CreateSourceMapParams['platform'],
 ): GraphQLResponse => {
   if (
     !originalGraphqlResponse ||
@@ -80,6 +81,7 @@ export const encodeGraphQLResponse = (
           editorInterface,
           fieldType,
           targetOrigin,
+          platform,
         });
 
         encodeField(fieldType, currentValue, hiddenStrings, target, pointer, mappings);

--- a/packages/content-source-maps/src/rest/encodeCPAResponse.ts
+++ b/packages/content-source-maps/src/rest/encodeCPAResponse.ts
@@ -1,6 +1,12 @@
 import { get, has } from 'json-pointer';
 
-import type { CPAEntry, CPAEntryCollection, EditorInterfaceSource, FieldType } from '../types.js';
+import type {
+  CPAEntry,
+  CPAEntryCollection,
+  EditorInterfaceSource,
+  FieldType,
+  CreateSourceMapParams,
+} from '../types.js';
 import {
   clone,
   createSourceMapMetadata,
@@ -13,7 +19,8 @@ const applyEncoding = (
   target: CPAEntry,
   fieldTypes: FieldType[],
   editorInterfaces: EditorInterfaceSource[],
-  targetOrigin?: 'https://app.contentful.com' | 'https://app.eu.contentful.com',
+  targetOrigin?: CreateSourceMapParams['targetOrigin'],
+  platform?: CreateSourceMapParams['platform'],
 ) => {
   if (!target.fields) {
     return;
@@ -72,6 +79,7 @@ const applyEncoding = (
           editorInterface,
           fieldType,
           targetOrigin,
+          platform,
         });
 
         encodeField(fieldType, currentValue, hiddenStrings, target, formattedPointer, mappings);
@@ -88,6 +96,7 @@ const applyEncoding = (
             editorInterface,
             fieldType,
             targetOrigin,
+            platform,
           });
 
           encodeField(
@@ -109,7 +118,8 @@ const applyEncoding = (
 
 export const encodeCPAResponse = (
   CPAResponse: CPAEntry | CPAEntryCollection,
-  targetOrigin?: 'https://app.contentful.com' | 'https://app.eu.contentful.com',
+  targetOrigin?: CreateSourceMapParams['targetOrigin'],
+  platform?: CreateSourceMapParams['platform'],
 ): CPAEntry | CPAEntryCollection => {
   const modifiedCPAResponse = clone(
     CPAResponse as unknown as Record<string, unknown>,
@@ -127,15 +137,17 @@ export const encodeCPAResponse = (
     } = collection.sys;
     const { items, includes } = collection;
 
-    items.forEach((target) => applyEncoding(target, fieldTypes, editorInterfaces, targetOrigin));
+    items.forEach((target) =>
+      applyEncoding(target, fieldTypes, editorInterfaces, targetOrigin, platform),
+    );
     if (includes && includes.Entry) {
       includes.Entry.forEach((entry) =>
-        applyEncoding(entry, fieldTypes, editorInterfaces, targetOrigin),
+        applyEncoding(entry, fieldTypes, editorInterfaces, targetOrigin, platform),
       );
     }
     if (includes && includes.Asset) {
       includes.Asset.forEach((asset) =>
-        applyEncoding(asset, fieldTypes, editorInterfaces, targetOrigin),
+        applyEncoding(asset, fieldTypes, editorInterfaces, targetOrigin, platform),
       );
     }
     // Single entity
@@ -151,6 +163,7 @@ export const encodeCPAResponse = (
       entry.sys.contentSourceMapsLookup.fieldTypes,
       entry.sys.contentSourceMapsLookup.editorInterfaces,
       targetOrigin,
+      platform,
     );
   }
 

--- a/packages/content-source-maps/src/types.ts
+++ b/packages/content-source-maps/src/types.ts
@@ -6,22 +6,38 @@ import type {
   EntrySkeletonType,
 } from 'contentful';
 
+type ContentfulMetadata = {
+  space: string;
+  environment: string;
+  entity: string;
+  entityType: string;
+  field: string;
+  locale: string;
+  editorInterface: {
+    widgetNamespace: string;
+    widgetId: string;
+  };
+  fieldType: string;
+};
+
 export type SourceMapMetadata = {
   origin: string;
-  href: string;
-  contentful: {
-    space: string;
-    environment: string;
-    entity: string;
-    entityType: string;
-    field: string;
-    locale: string;
-    editorInterface: {
-      widgetNamespace: string;
-      widgetId: string;
-    };
-    fieldType: string;
-  };
+} & (
+  | { href: string; contentful?: ContentfulMetadata }
+  | { href?: string; contentful: ContentfulMetadata }
+);
+
+export type CreateSourceMapParams = {
+  entityId: string;
+  entityType: string;
+  space: string;
+  environment: string;
+  field: string;
+  locale: string;
+  editorInterface: EditorInterfaceSource;
+  fieldType: string;
+  targetOrigin?: 'https://app.contentful.com' | 'https://app.eu.contentful.com';
+  platform?: 'contentful' | 'vercel';
 };
 
 export type Source = {

--- a/packages/content-source-maps/src/utils.ts
+++ b/packages/content-source-maps/src/utils.ts
@@ -5,7 +5,7 @@ import { encodeRichTextValue } from './richText.js';
 import type {
   CPAEntry,
   CPAMappings,
-  EditorInterfaceSource,
+  CreateSourceMapParams,
   FieldType,
   GraphQLMappings,
   GraphQLResponse,
@@ -24,23 +24,14 @@ export const createSourceMapMetadata = ({
   editorInterface,
   fieldType,
   targetOrigin,
-}: {
-  entityId: string;
-  entityType: string;
-  space: string;
-  environment: string;
-  field: string;
-  locale: string;
-  editorInterface: EditorInterfaceSource;
-  fieldType: string;
-  targetOrigin?: 'https://app.contentful.com' | 'https://app.eu.contentful.com';
-}): SourceMapMetadata => {
+  platform,
+}: CreateSourceMapParams): SourceMapMetadata => {
   const targetOriginUrl = targetOrigin || 'https://app.contentful.com';
   const basePath = `${targetOriginUrl}/spaces/${space}/environments/${environment}`;
   const entityRoute = entityType === 'Entry' ? 'entries' : 'assets';
   const href = `${basePath}/${entityRoute}/${entityId}/?focusedField=${field}&focusedLocale=${locale}`;
 
-  return {
+  const result: SourceMapMetadata = {
     origin: 'contentful.com',
     href,
     contentful: {
@@ -54,6 +45,16 @@ export const createSourceMapMetadata = ({
       fieldType,
     },
   };
+
+  if (platform === 'vercel') {
+    delete result.contentful;
+  }
+
+  if (platform === 'contentful') {
+    delete result.href;
+  }
+
+  return result;
 };
 
 export const isBuiltinNamespace = (namespace: WidgetNamespace) =>

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/fixtures/contentSourceMap.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/fixtures/contentSourceMap.ts
@@ -1,10 +1,12 @@
 import type { SourceMapMetadata } from '@contentful/content-source-maps';
 
+type ContentfulMetadata = Exclude<SourceMapMetadata['contentful'], undefined>;
+
 export function createSourceMapFixture(
   entityId: string,
   overrides?: {
     origin?: string;
-    contentful?: Partial<Omit<SourceMapMetadata['contentful'], 'entity'>>;
+    contentful?: Partial<Omit<ContentfulMetadata, 'entity'>>;
   },
 ): SourceMapMetadata {
   const origin = overrides?.origin ?? 'contentful.com';

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -1,6 +1,8 @@
 import { decode, type SourceMapMetadata } from '@contentful/content-source-maps';
 import { VERCEL_STEGA_REGEX } from '@vercel/stega';
 
+import { debug } from '../helpers/debug.js';
+import { InspectorModeOptions } from './index.js';
 import {
   InspectorModeAssetAttributes,
   InspectorModeAttributes,
@@ -8,7 +10,6 @@ import {
   InspectorModeEntryAttributes,
   InspectorModeSharedAttributes,
 } from './types.js';
-import { InspectorModeOptions } from './index.js';
 
 export type AutoTaggedElement<T = Node> = {
   element: T;
@@ -223,6 +224,7 @@ export function getAllTaggedElements({
   for (const { node, text } of stegaNodes) {
     const sourceMap = decode(text);
     if (!sourceMap || !sourceMap.origin.includes('contentful.com')) {
+      debug.warn;
       continue;
     }
 
@@ -257,6 +259,17 @@ export function getAllTaggedElements({
   );
 
   for (const { element, sourceMap } of uniqElementsForTagging) {
+    if (!sourceMap.contentful) {
+      debug.warn(
+        'Element has missing information in their ContentSourceMap, please check if you have restricted the platform for the encoding. (Missing parameter: `contentful`)',
+        {
+          element,
+          sourceMap,
+        },
+      );
+      continue;
+    }
+
     const attributes: InspectorModeSharedAttributes = {
       fieldId: sourceMap.contentful.field,
       locale: sourceMap.contentful.locale,


### PR DESCRIPTION
Provides the ability to reduce the payload of the hidden strings if only one platform for previewing is used
- using `contentful` - removing the `href` property
- using `vercel` - removing the `contentful` property
