### PR TITLE
chore: test out new swc config with react export

### DIFF
--- a/packages/live-preview-sdk/package.json
+++ b/packages/live-preview-sdk/package.json
@@ -16,6 +16,11 @@
       "default": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
     },
+    "./react": {
+      "import": "./dist/react.js",
+      "require": "./dist/react.cjs",
+      "types": "./dist/react.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
testing 4.3.0-alpha.6 revealed that we still need the react export in the package.json