### PR TITLE
fix: rich text block based auto tagging [TOL-2101]

### DIFF
--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
@@ -205,66 +205,6 @@ describe('getAllTaggedElements', () => {
     });
 
     describe('grouping information', () => {
-      it('should group sibling elements with the same information', () => {
-        const dom = html(`
-          <div id="richtext">
-            <p id="node-1">${combine('Hello', metadata)}</p>
-            <p id="node-2">${combine('World', metadata)}</p>
-            <p id="node-3"><b>${combine('!', metadata)}</b></p>
-            <p id="node-4">${combine('Lorem', metadata)} ${combine('Ipsum', metadata)}</p>
-          </div>
-        `);
-
-        const { taggedElements: elements } = getAllTaggedElements({
-          root: dom,
-          options: { locale: 'en-US' },
-        });
-
-        expect(elements).toHaveLength(1);
-        expect(elements).toEqual([
-          {
-            attributes: {
-              entryId: 'test-entry-id',
-              environment: 'master',
-              fieldId: 'title',
-              locale: 'en-US',
-              space: 'master',
-            },
-            element: dom.getElementById('richtext'),
-          },
-        ]);
-      });
-
-      it('should group sibling elements with the same information (nested structure)', () => {
-        const dom = html(`
-          <div id="richtext">
-            <p id="node-1"><span>${combine('Hello', metadata)}</span></p>
-            <p id="node-2"><span>${combine('World', metadata)}</span></p>
-            <p id="node-3"><b>${combine('!', metadata)}</b></p>
-            <p id="node-4"><span>${combine('Lorem', metadata)} ${combine('Ipsum', metadata)}</span></p>
-          </div>
-        `);
-
-        const { taggedElements: elements } = getAllTaggedElements({
-          root: dom,
-          options: { locale: 'en-US' },
-        });
-
-        expect(elements).toHaveLength(1);
-        expect(elements).toEqual([
-          {
-            attributes: {
-              entryId: 'test-entry-id',
-              environment: 'master',
-              fieldId: 'title',
-              locale: 'en-US',
-              space: 'master',
-            },
-            element: dom.getElementById('richtext'),
-          },
-        ]);
-      });
-
       it('should not tag nested elements with the same information', () => {
         const dom = html(`
           <p id="node-1">${combine('Hello', metadata)}<strong>${combine('World', metadata)}</strong>!</p>
@@ -314,7 +254,7 @@ describe('getAllTaggedElements', () => {
           options: { locale: 'en-US' },
         });
 
-        expect(elements).toHaveLength(3);
+        expect(elements).toHaveLength(4);
         expect(elements).toEqual([
           {
             attributes: {
@@ -324,7 +264,17 @@ describe('getAllTaggedElements', () => {
               locale: 'en-US',
               space: 'master',
             },
-            element: dom.getElementById('richtext'),
+            element: dom.getElementById('node-1'),
+          },
+          {
+            attributes: {
+              entryId: 'test-entry-id',
+              environment: 'master',
+              fieldId: 'title',
+              locale: 'en-US',
+              space: 'master',
+            },
+            element: dom.getElementById('node-2'),
           },
           {
             attributes: {

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -103,50 +103,6 @@ function isSameElement(a: AutoTaggedElement, b: AutoTaggedElement): boolean {
   return true;
 }
 
-function getParent(
-  child: Element,
-  sourceMap: SourceMapMetadata,
-  limit = 3,
-): { element: Element; counters: { sameInformation: number; tagged: number; all: number } } | null {
-  if (limit === 0) {
-    return null;
-  }
-
-  const element = child.parentElement;
-  if (element) {
-    const counters = {
-      sameInformation: 0,
-      tagged: 0,
-      all: 0,
-    };
-
-    let sibling = child.nextElementSibling;
-    while (sibling) {
-      const siblingSourceMap = decode(sibling.textContent || '');
-      if (siblingSourceMap) {
-        counters.tagged += 1;
-        if (siblingSourceMap.href === sourceMap.href) {
-          counters.sameInformation = +1;
-        }
-      }
-      counters.all += 1;
-      sibling = sibling.nextElementSibling;
-    }
-
-    const parentInformation = getParent(element, sourceMap, limit - 1);
-    if (parentInformation && parentInformation.counters.sameInformation >= 1) {
-      return parentInformation;
-    }
-
-    if (counters.sameInformation >= 1) {
-      // at least one more siblings has the same information
-      return { element, counters };
-    }
-  }
-
-  return null;
-}
-
 export function findStegaNodes(container: HTMLElement) {
   let baseArray: HTMLElement[] = [];
   if (typeof container.matches === 'function' && container.matches('*')) {
@@ -243,14 +199,7 @@ export function getAllTaggedElements({
       continue;
     }
 
-    // TODO: Performance optimisation: only do for richtext
-    const wrapper = getParent(node, sourceMap);
-    if (wrapper) {
-      elementsForTagging.push({ element: wrapper.element, sourceMap: sourceMap });
-    } else {
-      // No sibling element with the same information, add the element directly
-      elementsForTagging.push({ element: node, sourceMap: sourceMap });
-    }
+    elementsForTagging.push({ element: node, sourceMap: sourceMap });
   }
 
   // Filter duplicate elements, so we don't tag them again and again


### PR DESCRIPTION
Auto-tag all block based elements in rich text instead of just the parent wrapper rich text element

## Before
<img width="1728" alt="Screenshot 2024-08-06 at 15 12 09" src="https://github.com/user-attachments/assets/4b8480ed-8107-4986-a397-f6265132c1d4">


## After

<img width="1728" alt="Screenshot 2024-08-06 at 15 10 16" src="https://github.com/user-attachments/assets/e854b1b7-c4f8-4871-b615-b82f3d5fc4f5">
