### PR TITLE
feat: add vercel tracking query param [TOL-1916]

### DIFF
--- a/packages/content-source-maps/src/__tests__/graphql.spec.ts
+++ b/packages/content-source-maps/src/__tests__/graphql.spec.ts
@@ -78,7 +78,7 @@ describe('Content Source Maps with the GraphQL API', () => {
     testEncodingDecoding(encodedGraphQLResponse.data.post, {
       '/title': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -95,7 +95,7 @@ describe('Content Source Maps with the GraphQL API', () => {
       },
       '/subtitle': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -167,7 +167,7 @@ describe('Content Source Maps with the GraphQL API', () => {
     testEncodingDecoding(encodedGraphQLResponse.data.post, {
       '/longText': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=longText&focusedLocale=en-US',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=longText&focusedLocale=en-US?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -227,7 +227,7 @@ describe('Content Source Maps with the GraphQL API', () => {
       const decodedValue = decode(item);
       expect(decodedValue).toEqual({
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=list&focusedLocale=en-US',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=list&focusedLocale=en-US?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -349,7 +349,7 @@ describe('Content Source Maps with the GraphQL API', () => {
     testEncodingDecoding(encodedGraphQLResponse.data.post, {
       '/title': {
         origin: 'contentful.com',
-        href: 'https://app.eu.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
+        href: 'https://app.eu.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -366,7 +366,7 @@ describe('Content Source Maps with the GraphQL API', () => {
       },
       '/subtitle': {
         origin: 'contentful.com',
-        href: 'https://app.eu.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US',
+        href: 'https://app.eu.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -465,7 +465,7 @@ describe('Content Source Maps with the GraphQL API', () => {
         const entityId = entityIds[index];
         const expected = {
           origin: 'contentful.com',
-          href: `${baseUrl}/spaces/${spaceId}/environments/${environment}/entries/${entityId}/?focusedField=${field}&focusedLocale=${locale}`,
+          href: `${baseUrl}/spaces/${spaceId}/environments/${environment}/entries/${entityId}/?focusedField=${field}&focusedLocale=${locale}?source=vercel-content-link`,
           contentful: {
             space: spaceId,
             environment,
@@ -550,7 +550,7 @@ describe('Content Source Maps with the GraphQL API', () => {
     testEncodingDecoding(encodedGraphQLResponse.data.postCollection.items[0], {
       '/akanTitle': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=ak',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=ak?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -567,7 +567,7 @@ describe('Content Source Maps with the GraphQL API', () => {
       },
       '/aghemTitle': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=agq',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=agq?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -584,7 +584,7 @@ describe('Content Source Maps with the GraphQL API', () => {
       },
       '/spanishTitle': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=es',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=es?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -788,7 +788,7 @@ describe('Content Source Maps with the GraphQL API', () => {
     testEncodingDecoding(encodedGraphQLResponse.data.post, {
       '/rte/json/content/0/content/0/value': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -805,7 +805,7 @@ describe('Content Source Maps with the GraphQL API', () => {
       },
       '/rte/json/content/0/content/2/value': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -823,7 +823,7 @@ describe('Content Source Maps with the GraphQL API', () => {
       // entry hyperlinks
       '/rte/json/content/0/content/3/content/0/value': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -843,7 +843,7 @@ describe('Content Source Maps with the GraphQL API', () => {
       '/rte/json/content/0/content/4/data/uri': undefined,
       '/rte/json/content/0/content/4/content/0/value': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US?source=vercel-content-link',
         contentful: {
           space: 'foo',
           environment: 'master',
@@ -1008,11 +1008,11 @@ describe('Content Source Maps with the GraphQL API', () => {
     testEncodingDecoding(encodedGraphQLResponse.data.post, {
       '/title': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
       },
       '/subtitle': {
         origin: 'contentful.com',
-        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US',
+        href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US?source=vercel-content-link',
       },
     });
   });
@@ -1261,7 +1261,7 @@ describe('Content Source Maps with the GraphQL API', () => {
       testEncodingDecoding(encodedGraphQLResponse.data.post, {
         '/rte/json/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -1278,7 +1278,7 @@ describe('Content Source Maps with the GraphQL API', () => {
         },
         '/rte/json/content/0/content/2/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -1295,7 +1295,7 @@ describe('Content Source Maps with the GraphQL API', () => {
         },
         '/title': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -1354,7 +1354,7 @@ describe('Content Source Maps with the GraphQL API', () => {
       testEncodingDecoding(encodedGraphQLResponse.data.post, {
         '/title': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',

--- a/packages/content-source-maps/src/__tests__/rest.spec.ts
+++ b/packages/content-source-maps/src/__tests__/rest.spec.ts
@@ -235,7 +235,7 @@ describe('Content Source Maps with the CPA', () => {
       const mappings = {
         '/items/0/fields/title/en-US': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -252,7 +252,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/items/0/fields/title/af': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=af',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=af?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -269,7 +269,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/items/0/fields/longText/en-US': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=longText&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=longText&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -286,7 +286,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/items/0/fields/longText/af': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=longText&focusedLocale=af',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=longText&focusedLocale=af?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -303,7 +303,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/items/0/fields/richText/en-US/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -320,7 +320,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/items/0/fields/richText/af/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -337,7 +337,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/items/0/fields/richText/af/content/1/content/0/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -354,7 +354,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/includes/Entry/0/fields/title/en-US': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entry2Id/?focusedField=title&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entry2Id/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -371,7 +371,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/includes/Entry/0/fields/richText/en-US/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entry2Id/?focusedField=richText&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entry2Id/?focusedField=richText&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -388,7 +388,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/includes/Asset/0/fields/title/en-US': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/assets/assetId/?focusedField=title&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/assets/assetId/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -410,7 +410,7 @@ describe('Content Source Maps with the CPA', () => {
         const decodedValue = decode(item);
         expect(decodedValue).toEqual({
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=list&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=list&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -512,7 +512,7 @@ describe('Content Source Maps with the CPA', () => {
       const mappings = {
         '/items/0/fields/title': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=af',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=af?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -529,7 +529,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/items/0/fields/richText/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -551,7 +551,7 @@ describe('Content Source Maps with the CPA', () => {
         const decodedValue = decode(item);
         expect(decodedValue).toEqual({
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=list&focusedLocale=af',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=list&focusedLocale=af?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -722,7 +722,7 @@ describe('Content Source Maps with the CPA', () => {
       const mappings = {
         '/fields/title/en-US': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -739,7 +739,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/fields/title/af': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=af',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=af?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -756,7 +756,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/fields/title/nl-BE': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=nl-BE',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=nl-BE?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -773,7 +773,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/fields/richText/en-US/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -790,7 +790,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/fields/richText/af/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -807,7 +807,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/fields/richText/af/content/1/content/0/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -824,7 +824,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/fields/richText/nl-BE/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=nl-BE',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=nl-BE?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -846,7 +846,7 @@ describe('Content Source Maps with the CPA', () => {
         const decodedValue = decode(item);
         expect(decodedValue).toEqual({
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=checkboxes&focusedLocale=nl-BE',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=checkboxes&focusedLocale=nl-BE?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -933,7 +933,7 @@ describe('Content Source Maps with the CPA', () => {
       const mappings = {
         '/fields/title': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -950,7 +950,7 @@ describe('Content Source Maps with the CPA', () => {
         },
         '/fields/richText/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US?source=vercel-content-link',
           contentful: {
             space: 'spaceId',
             environment: 'master',
@@ -1042,11 +1042,11 @@ describe('Content Source Maps with the CPA', () => {
       const mappings = {
         '/fields/title': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
         },
         '/fields/richText/content/0/content/0/value': {
           origin: 'contentful.com',
-          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US',
+          href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US?source=vercel-content-link',
         },
       };
 

--- a/packages/content-source-maps/src/utils.ts
+++ b/packages/content-source-maps/src/utils.ts
@@ -29,7 +29,8 @@ export const createSourceMapMetadata = ({
   const targetOriginUrl = targetOrigin || 'https://app.contentful.com';
   const basePath = `${targetOriginUrl}/spaces/${space}/environments/${environment}`;
   const entityRoute = entityType === 'Entry' ? 'entries' : 'assets';
-  const href = `${basePath}/${entityRoute}/${entityId}/?focusedField=${field}&focusedLocale=${locale}`;
+  //href is used only by Vercel to open the entry in the Contentful web app
+  const href = `${basePath}/${entityRoute}/${entityId}/?focusedField=${field}&focusedLocale=${locale}?source=vercel-content-link`;
 
   const result: SourceMapMetadata = {
     origin: 'contentful.com',
@@ -46,6 +47,7 @@ export const createSourceMapMetadata = ({
     },
   };
 
+  // If the user has specified a platform, we remove the fields that are not relevant to that platform
   if (platform === 'vercel') {
     delete result.contentful;
   }


### PR DESCRIPTION
Add a `?source=vercel-content-link` query param to the URL when users are clicking on ‘Open in Contentful’ link in the Vercel Visual Editor