### PR TITLE
fix: adding new property to tagged elements that are overlapped by others [TOL-2408]

### DIFF
--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/addCalculatedAttributesToTaggedElements.test.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/addCalculatedAttributesToTaggedElements.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { InspectorModeDataAttributes } from '../types.js';
+import { addCalculatedAttributesToTaggedElements, getAllTaggedElements } from '../utils.js';
+
+describe('addCalculatedAttributesToTaggedElements', () => {
+  const dataEntry = InspectorModeDataAttributes.ENTRY_ID;
+  const dataField = InspectorModeDataAttributes.FIELD_ID;
+  const dataLocale = InspectorModeDataAttributes.LOCALE;
+
+  const html = (text: string) => {
+    return new DOMParser().parseFromString(text, 'text/html');
+  };
+
+  describe('visibility attributes', () => {
+    it('should return if tagged element is covered by another one of a higher z-index', () => {
+      const dom = html(`
+        <div>
+          <!-- Entries -->
+          <div
+            id="entry-1"
+          ${dataEntry}="entry-1"
+          ${dataField}="field-1"
+          ${dataLocale}="locale-1"
+          ></div>
+          <div
+            id="covering-element"
+            style="position: absolute; z-index: 100; top: 0; left: 0; width: 100%; height: 100%;"
+          ></div>
+        </div>
+        `);
+
+      dom.getElementById('entry-1')!.checkVisibility = () => true;
+      const entry1Coordinates = {
+        bottom: 100,
+        height: 100,
+        left: 10,
+        right: 100,
+        top: 10,
+        width: 100,
+        x: 10,
+        y: 10,
+      };
+      const entry1BoundingClientRect = {
+        ...entry1Coordinates,
+        toJSON: () => entry1Coordinates,
+      };
+      dom.getElementById('entry-1')!.getBoundingClientRect = () => entry1BoundingClientRect;
+
+      // covering element
+      dom.getElementById('covering-element')!.checkVisibility = () => true;
+      const coveringElementCoordinates = {
+        bottom: 200,
+        height: 200,
+        left: 0,
+        right: 200,
+        top: 0,
+        width: 200,
+        x: 0,
+        y: 0,
+      };
+      const coveringElementBoundingClientRect = {
+        ...coveringElementCoordinates,
+        toJSON: () => coveringElementCoordinates,
+      };
+      dom.getElementById('covering-element')!.getBoundingClientRect = () =>
+        coveringElementBoundingClientRect;
+
+      const { taggedElements: elements } = getAllTaggedElements({
+        root: dom,
+        options: { locale: 'locale-1' },
+      });
+      const elementsWithCalculatedAttributes = addCalculatedAttributesToTaggedElements(
+        elements,
+        dom,
+      );
+      expect(elementsWithCalculatedAttributes).toEqual([
+        {
+          attributes: {
+            entryId: 'entry-1',
+            environment: undefined,
+            fieldId: 'field-1',
+            locale: 'locale-1',
+            space: undefined,
+            manuallyTagged: true,
+          },
+          element: dom.getElementById('entry-1'),
+          isVisible: true,
+          isCoveredByOtherElement: true,
+          zIndex: 0,
+          coordinates: entry1BoundingClientRect,
+          layerCoordinates: entry1BoundingClientRect,
+        },
+      ]);
+    });
+  });
+});

--- a/packages/live-preview-sdk/src/inspectorMode/index.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/index.ts
@@ -5,10 +5,13 @@ import { type MessageFromEditor } from '../messages.js';
 import {
   InspectorModeDataAttributes,
   InspectorModeEventMethods,
-  type InspectorModeAttributes,
   type InspectorModeChangedMessage,
 } from './types.js';
-import { addCalculatedAttributesToTaggedElements, getAllTaggedElements } from './utils.js';
+import {
+  addCalculatedAttributesToTaggedElements,
+  getAllTaggedElements,
+  TaggedElement,
+} from './utils.js';
 
 export type InspectorModeOptions = {
   locale: string;
@@ -16,16 +19,6 @@ export type InspectorModeOptions = {
   environment?: string;
   targetOrigin: string[];
   ignoreManuallyTaggedElements?: boolean;
-};
-
-type TaggedElement = {
-  attributes: InspectorModeAttributes | null;
-  coordinates: DOMRect;
-  element: Element;
-  isVisible: boolean;
-  zIndex: number;
-  layerCoordinates: DOMRect;
-  isCoveredByOtherElement: boolean;
 };
 
 export class InspectorMode {
@@ -242,8 +235,8 @@ export class InspectorMode {
       {
         elements: this.taggedElements.map((taggedElement) => ({
           // Important: do not add `element` as it can't be cloned by sendMessage
-          coordinates: taggedElement.coordinates,
-          isVisible: taggedElement.isVisible,
+          coordinates: taggedElement.coordinates!,
+          isVisible: !!taggedElement.isVisible,
           attributes: taggedElement.attributes,
           isHovered: this.hoveredElement === taggedElement.element,
           isCoveredByOtherElement: !!taggedElement.isCoveredByOtherElement,

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -325,7 +325,7 @@ const addCoordinatesToTaggedElements = (
  * but need to calculate based on the current state of the document
  */
 export const addCalculatedAttributesToTaggedElements = (
-  taggedElements: Partial<TaggedElement>[],
+  taggedElements: PrecaulculatedTaggedElement[],
   root = window.document,
 ): TaggedElement[] => {
   const taggedElementWithCoordinates = addCoordinatesToTaggedElements(taggedElements);

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -317,7 +317,6 @@ export const getAllLayersInDocument = (
       });
     }
   }
-  console.log({ elementsAfter: Array.from(allElements) });
   return layers;
 };
 
@@ -378,14 +377,13 @@ const addCoordinatesAndLayerAttributesToTaggedElements = (
     const layerCoordinates = closestParent
       ? closestParent.getBoundingClientRect()
       : elementCoordinates;
-    const nextElement = {
+    return {
       element,
       coordinates: elementCoordinates,
       attributes,
       zIndex: zIndex ? Number(zIndex) : 0,
       layerCoordinates,
     };
-    return nextElement;
   });
 };
 

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -16,13 +16,16 @@ export type AutoTaggedElement<T = Node> = {
   sourceMap: SourceMapMetadata;
 };
 
-export interface TaggedElement {
+interface PrecaulculatedTaggedElement {
   element: Element;
   attributes: InspectorModeAttributes | null;
-  isHovered?: boolean;
-  isVisible?: boolean;
-  coordinates?: DOMRect;
-  isCoveredByOtherElement?: boolean;
+}
+
+export interface TaggedElement extends PrecaulculatedTaggedElement {
+  isHovered: boolean;
+  isVisible: boolean;
+  coordinates: DOMRect;
+  isCoveredByOtherElement: boolean;
 }
 
 const isTaggedElement = (node?: Node | null): boolean => {
@@ -136,7 +139,10 @@ function getNodeText(node: HTMLElement): string {
     .join('');
 }
 
-function hasTaggedParent(node: HTMLElement, taggedElements: TaggedElement[]): boolean {
+function hasTaggedParent(
+  node: HTMLElement,
+  taggedElements: PrecaulculatedTaggedElement[],
+): boolean {
   for (const tagged of taggedElements) {
     if (tagged.element === node || tagged.element.contains(node)) {
       return true;
@@ -158,7 +164,7 @@ export function getAllTaggedElements({
   options: Omit<InspectorModeOptions, 'targetOrigin'>;
   ignoreManual?: boolean;
 }): {
-  taggedElements: TaggedElement[];
+  taggedElements: PrecaulculatedTaggedElement[];
   manuallyTaggedCount: number;
   automaticallyTaggedCount: number;
   autoTaggedElements: AutoTaggedElement<Element>[];
@@ -170,7 +176,7 @@ export function getAllTaggedElements({
       );
 
   //Spread operator is necessary to convert the NodeList to an array
-  const taggedElements: TaggedElement[] = [...alreadyTagged]
+  const taggedElements: PrecaulculatedTaggedElement[] = [...alreadyTagged]
     .map((element: Element) => ({
       element,
       attributes: getManualInspectorModeAttributes(element, options),
@@ -265,7 +271,7 @@ export function getAllTaggedEntries({
   return [
     ...new Set(
       getAllTaggedElements({ options })
-        .taggedElements.map((element: TaggedElement) => {
+        .taggedElements.map((element: PrecaulculatedTaggedElement) => {
           if (element.attributes && 'entryId' in element.attributes) {
             return element.attributes.entryId;
           }


### PR DESCRIPTION
Checking intersections of overlapping tagged elements and adding an attribute which is sent to the editor to stop rendering tagged elements which should be hidden.

- For each 4 corners of the tagged elements calculate what the topmost element is at that point
- If the topmost element is not the tagged element add property to hide tagged element
