### PR TITLE
fix: remove redundant contentful info CSM [NONE]

### DIFF
--- a/packages/content-source-maps/src/__tests__/encode.spec.ts
+++ b/packages/content-source-maps/src/__tests__/encode.spec.ts
@@ -9,12 +9,6 @@ describe('Stega Function Tests', () => {
     origin: 'example.com',
     href: 'https://example.com/page',
     contentful: {
-      space: 'space-id',
-      environment: 'master',
-      entity: 'entity-id',
-      entityType: 'Article',
-      field: 'title',
-      locale: 'en-US',
       editorInterface: {
         widgetNamespace: 'builtin',
         widgetId: 'singleLine',

--- a/packages/content-source-maps/src/__tests__/graphql.spec.ts
+++ b/packages/content-source-maps/src/__tests__/graphql.spec.ts
@@ -80,12 +80,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'title',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'singleLine',
             widgetNamespace: 'builtin',
@@ -97,12 +91,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'subtitle',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'singleLine',
             widgetNamespace: 'builtin',
@@ -169,12 +157,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=longText&focusedLocale=en-US&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'longText',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'multipleLine',
             widgetNamespace: 'builtin',
@@ -229,12 +211,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=list&focusedLocale=en-US&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'list',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           fieldType: 'Array',
           editorInterface: {
             widgetId: 'listInput',
@@ -351,12 +327,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.eu.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'title',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'singleLine',
             widgetNamespace: 'builtin',
@@ -368,12 +338,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.eu.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=subtitle&focusedLocale=en-US&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'subtitle',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'singleLine',
             widgetNamespace: 'builtin',
@@ -458,7 +422,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         const baseUrl = 'https://app.contentful.com';
         const spaceId = 'foo';
         const environment = 'master';
-        const entityType = 'Entry';
         const field = 'title';
         const locale = 'en-US';
         const entityIds = ['a1b2c3', 'd4e5f6', 'g7h8i9'];
@@ -467,12 +430,6 @@ describe('Content Source Maps with the GraphQL API', () => {
           origin: 'contentful.com',
           href: `${baseUrl}/spaces/${spaceId}/environments/${environment}/entries/${entityId}/?focusedField=${field}&focusedLocale=${locale}&source=vercel-content-link`,
           contentful: {
-            space: spaceId,
-            environment,
-            field,
-            locale,
-            entity: entityId,
-            entityType,
             editorInterface: {
               widgetId: 'singleLine',
               widgetNamespace: 'builtin',
@@ -552,12 +509,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=ak&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'title',
-          locale: 'ak',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'singleLine',
             widgetNamespace: 'builtin',
@@ -569,12 +520,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=agq&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'title',
-          locale: 'agq',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'singleLine',
             widgetNamespace: 'builtin',
@@ -586,12 +531,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=es&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'title',
-          locale: 'es',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'singleLine',
             widgetNamespace: 'builtin',
@@ -790,12 +729,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'rte',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'richTextEditor',
             widgetNamespace: 'builtin',
@@ -807,12 +740,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'rte',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'richTextEditor',
             widgetNamespace: 'builtin',
@@ -825,12 +752,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'rte',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'richTextEditor',
             widgetNamespace: 'builtin',
@@ -845,12 +766,6 @@ describe('Content Source Maps with the GraphQL API', () => {
         origin: 'contentful.com',
         href: 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US&source=vercel-content-link',
         contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'rte',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
           editorInterface: {
             widgetId: 'richTextEditor',
             widgetNamespace: 'builtin',
@@ -1017,93 +932,6 @@ describe('Content Source Maps with the GraphQL API', () => {
     });
   });
 
-  test('adds only the `contentful` parameter in the encoding if platform `contentful` is configured', () => {
-    const graphQLResponse: GraphQLResponse = {
-      data: {
-        post: {
-          title: 'Title of the post',
-          subtitle: 'Subtitle of the post',
-        },
-      },
-      extensions: {
-        contentSourceMaps: {
-          spaces: ['foo'],
-          environments: ['master'],
-          fieldTypes: ['Symbol'],
-          editorInterfaces: [
-            {
-              widgetId: 'singleLine',
-              widgetNamespace: 'builtin',
-            },
-          ],
-          fields: ['title', 'subtitle'],
-          locales: ['en-US'],
-          entries: [{ space: 0, environment: 0, id: 'a1b2c3' }],
-          assets: [],
-          mappings: {
-            '/data/post/title': {
-              source: {
-                entry: 0,
-                field: 0,
-                locale: 0,
-                fieldType: 0,
-                editorInterface: 0,
-              },
-            },
-            '/data/post/subtitle': {
-              source: {
-                entry: 0,
-                field: 1,
-                locale: 0,
-                fieldType: 0,
-                editorInterface: 0,
-              },
-            },
-          },
-        },
-      },
-    };
-    const encodedGraphQLResponse = encodeGraphQLResponse(
-      graphQLResponse,
-      'https://app.contentful.com',
-      'contentful',
-    );
-    testEncodingDecoding(encodedGraphQLResponse.data.post, {
-      '/title': {
-        origin: 'contentful.com',
-        contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'title',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
-          editorInterface: {
-            widgetId: 'singleLine',
-            widgetNamespace: 'builtin',
-          },
-          fieldType: 'Symbol',
-        },
-      },
-      '/subtitle': {
-        origin: 'contentful.com',
-        contentful: {
-          space: 'foo',
-          environment: 'master',
-          field: 'subtitle',
-          locale: 'en-US',
-          entity: 'a1b2c3',
-          entityType: 'Entry',
-          editorInterface: {
-            widgetId: 'singleLine',
-            widgetNamespace: 'builtin',
-          },
-          fieldType: 'Symbol',
-        },
-      },
-    });
-  });
-
   describe('editor interfaces', () => {
     UNSUPPORTED_WIDGETS.forEach((widget) => {
       test(`does not encode ${widget}`, () => {
@@ -1263,12 +1091,6 @@ describe('Content Source Maps with the GraphQL API', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'rte',
-            locale: 'en-US',
-            entity: 'a1b2c3',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -1280,12 +1102,6 @@ describe('Content Source Maps with the GraphQL API', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=rte&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'rte',
-            locale: 'en-US',
-            entity: 'a1b2c3',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -1297,12 +1113,6 @@ describe('Content Source Maps with the GraphQL API', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'en-US',
-            entity: 'a1b2c3',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'singleLine',
               widgetNamespace: 'builtin',
@@ -1356,12 +1166,6 @@ describe('Content Source Maps with the GraphQL API', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'en-US',
-            entity: 'a1b2c3',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'radio',
               widgetNamespace: 'app',

--- a/packages/content-source-maps/src/__tests__/rest.spec.ts
+++ b/packages/content-source-maps/src/__tests__/rest.spec.ts
@@ -237,12 +237,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'en-US',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'singleLine',
               widgetNamespace: 'builtin',
@@ -254,12 +248,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=af&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'af',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'singleLine',
               widgetNamespace: 'builtin',
@@ -271,12 +259,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=longText&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'longText',
-            locale: 'en-US',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'multipleLine',
               widgetNamespace: 'builtin',
@@ -288,12 +270,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=longText&focusedLocale=af&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'longText',
-            locale: 'af',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'multipleLine',
               widgetNamespace: 'builtin',
@@ -305,12 +281,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'richText',
-            locale: 'en-US',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -322,12 +292,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'richText',
-            locale: 'af',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -339,12 +303,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'richText',
-            locale: 'af',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -356,12 +314,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entry2Id/?focusedField=title&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'en-US',
-            entity: 'entry2Id',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'singleLine',
               widgetNamespace: 'builtin',
@@ -373,12 +325,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entry2Id/?focusedField=richText&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'richText',
-            locale: 'en-US',
-            entity: 'entry2Id',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -390,12 +336,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/assets/assetId/?focusedField=title&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'en-US',
-            entity: 'assetId',
-            entityType: 'Asset',
             editorInterface: {
               widgetId: 'singleLine',
               widgetNamespace: 'builtin',
@@ -412,12 +352,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=list&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'list',
-            locale: 'en-US',
-            entity: 'entryId',
-            entityType: 'Entry',
             fieldType: 'Array',
             editorInterface: {
               widgetId: 'tagEditor',
@@ -514,12 +448,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=af&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'af',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'singleLine',
               widgetNamespace: 'builtin',
@@ -531,12 +459,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'richText',
-            locale: 'af',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -553,12 +475,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=list&focusedLocale=af&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'list',
-            locale: 'af',
-            entity: 'entryId',
-            entityType: 'Entry',
             fieldType: 'Array',
             editorInterface: {
               widgetId: 'listInput',
@@ -724,12 +640,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'en-US',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'singleLine',
               widgetNamespace: 'builtin',
@@ -741,12 +651,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=af&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'af',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'singleLine',
               widgetNamespace: 'builtin',
@@ -758,12 +662,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=nl-BE&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'nl-BE',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'singleLine',
               widgetNamespace: 'builtin',
@@ -775,12 +673,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'richText',
-            locale: 'en-US',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -792,12 +684,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'richText',
-            locale: 'af',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -809,12 +695,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=af&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'richText',
-            locale: 'af',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -826,12 +706,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=nl-BE&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'richText',
-            locale: 'nl-BE',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -848,12 +722,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=checkboxes&focusedLocale=nl-BE&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'checkboxes',
-            locale: 'nl-BE',
-            entity: 'entryId',
-            entityType: 'Entry',
             fieldType: 'Array',
             editorInterface: {
               widgetId: 'checkbox',
@@ -935,12 +803,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=title&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'en-US',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'singleLine',
               widgetNamespace: 'builtin',
@@ -952,12 +814,6 @@ describe('Content Source Maps with the CPA', () => {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US&source=vercel-content-link',
           contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'richText',
-            locale: 'en-US',
-            entity: 'entryId',
-            entityType: 'Entry',
             editorInterface: {
               widgetId: 'richTextEditor',
               widgetNamespace: 'builtin',
@@ -1047,51 +903,6 @@ describe('Content Source Maps with the CPA', () => {
         '/fields/richText/content/0/content/0/value': {
           origin: 'contentful.com',
           href: 'https://app.contentful.com/spaces/spaceId/environments/master/entries/entryId/?focusedField=richText&focusedLocale=en-US&source=vercel-content-link',
-        },
-      };
-
-      testEncodingDecoding(encodedCPAResponse, mappings);
-    });
-
-    test('setting the platform to contentful removes the href information', () => {
-      const encodedCPAResponse = encodeCPAResponse(
-        response,
-        'https://app.contentful.com',
-        'contentful',
-      ) as CPAEntry;
-
-      const mappings = {
-        '/fields/title': {
-          origin: 'contentful.com',
-          contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'title',
-            locale: 'en-US',
-            entity: 'entryId',
-            entityType: 'Entry',
-            editorInterface: {
-              widgetId: 'singleLine',
-              widgetNamespace: 'builtin',
-            },
-            fieldType: 'Symbol',
-          },
-        },
-        '/fields/richText/content/0/content/0/value': {
-          origin: 'contentful.com',
-          contentful: {
-            space: 'spaceId',
-            environment: 'master',
-            field: 'richText',
-            locale: 'en-US',
-            entity: 'entryId',
-            entityType: 'Entry',
-            editorInterface: {
-              widgetId: 'richTextEditor',
-              widgetNamespace: 'builtin',
-            },
-            fieldType: 'RichText',
-          },
         },
       };
 

--- a/packages/content-source-maps/src/graphql/encodeGraphQLResponse.ts
+++ b/packages/content-source-maps/src/graphql/encodeGraphQLResponse.ts
@@ -1,6 +1,6 @@
 import { get, has } from 'json-pointer';
 
-import type { CreateSourceMapParams, GraphQLResponse } from '../types.js';
+import type { CreateSourceMapParams } from '../types.js';
 import {
   clone,
   createSourceMapMetadata,
@@ -9,11 +9,11 @@ import {
   isSupportedWidget,
 } from '../utils.js';
 
-export const encodeGraphQLResponse = (
-  originalGraphqlResponse: GraphQLResponse,
+export const encodeGraphQLResponse = <TResponse extends { data: any; extensions: any }>(
+  originalGraphqlResponse: TResponse,
   targetOrigin?: CreateSourceMapParams['targetOrigin'],
   platform?: CreateSourceMapParams['platform'],
-): GraphQLResponse => {
+): TResponse => {
   if (
     !originalGraphqlResponse ||
     !originalGraphqlResponse.extensions ||
@@ -25,9 +25,7 @@ export const encodeGraphQLResponse = (
     );
     return originalGraphqlResponse;
   }
-  const modifiedGraphqlResponse = clone(
-    originalGraphqlResponse as unknown as Record<string, unknown>,
-  ) as unknown as GraphQLResponse;
+  const modifiedGraphqlResponse = clone(originalGraphqlResponse);
   const {
     spaces,
     environments,

--- a/packages/content-source-maps/src/types.ts
+++ b/packages/content-source-maps/src/types.ts
@@ -7,12 +7,6 @@ import type {
 } from 'contentful';
 
 type ContentfulMetadata = {
-  space: string;
-  environment: string;
-  entity: string;
-  entityType: string;
-  field: string;
-  locale: string;
   editorInterface: {
     widgetNamespace: string;
     widgetId: string;
@@ -29,7 +23,7 @@ export type SourceMapMetadata = {
 
 export type CreateSourceMapParams = {
   entityId: string;
-  entityType: string;
+  entityType: 'Entry' | 'Asset';
   space: string;
   environment: string;
   field: string;

--- a/packages/content-source-maps/src/types.ts
+++ b/packages/content-source-maps/src/types.ts
@@ -117,10 +117,11 @@ export interface ContentSourceMapsLookup {
   editorInterfaces: EditorInterfaceSource[];
 }
 
-export interface GraphQLResponse {
-  data: any;
+export interface GraphQLResponse<TData = any> {
+  data: TData;
   extensions: {
-    contentSourceMaps: GraphQLContentSourceMaps;
+    contentSourceMaps?: GraphQLContentSourceMaps;
+    [key: string]: any;
   };
 }
 

--- a/packages/content-source-maps/src/utils.ts
+++ b/packages/content-source-maps/src/utils.ts
@@ -36,12 +36,6 @@ export const createSourceMapMetadata = ({
     origin: 'contentful.com',
     href,
     contentful: {
-      space,
-      environment,
-      field,
-      locale,
-      entity: entityId,
-      entityType,
       editorInterface,
       fieldType,
     },
@@ -50,10 +44,6 @@ export const createSourceMapMetadata = ({
   // If the user has specified a platform, we remove the fields that are not relevant to that platform
   if (platform === 'vercel') {
     delete result.contentful;
-  }
-
-  if (platform === 'contentful') {
-    delete result.href;
   }
 
   return result;

--- a/packages/content-source-maps/src/utils.ts
+++ b/packages/content-source-maps/src/utils.ts
@@ -29,7 +29,6 @@ export const createSourceMapMetadata = ({
   const targetOriginUrl = targetOrigin || 'https://app.contentful.com';
   const basePath = `${targetOriginUrl}/spaces/${space}/environments/${environment}`;
   const entityRoute = entityType === 'Entry' ? 'entries' : 'assets';
-  //href is used only by Vercel to open the entry in the Contentful web app
   const href = `${basePath}/${entityRoute}/${entityId}/?focusedField=${field}&focusedLocale=${locale}&source=vercel-content-link`;
 
   const result: SourceMapMetadata = {

--- a/packages/live-preview-sdk/src/index.ts
+++ b/packages/live-preview-sdk/src/index.ts
@@ -16,7 +16,11 @@ import {
 import { isValidMessage } from './helpers/validateMessage.js';
 import { InspectorMode } from './inspectorMode/index.js';
 import { InspectorModeDataAttributes, type InspectorModeTags } from './inspectorMode/types.js';
-import { getAllTaggedElements, getAllTaggedEntries } from './inspectorMode/utils.js';
+import {
+  getAllTaggedElements,
+  getAllTaggedEntries,
+  parseAttributesFromHref,
+} from './inspectorMode/utils.js';
 import { LiveUpdates } from './liveUpdates.js';
 import {
   LivePreviewPostMessageMethods,
@@ -395,4 +399,4 @@ export class ContentfulLivePreview {
 export { LIVE_PREVIEW_EDITOR_SOURCE, LIVE_PREVIEW_SDK_SOURCE } from './constants.js';
 
 export * from './messages.js';
-export { encodeGraphQLResponse, encodeCPAResponse, splitEncoding };
+export { encodeGraphQLResponse, encodeCPAResponse, splitEncoding, parseAttributesFromHref };

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/fixtures/contentSourceMap.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/fixtures/contentSourceMap.ts
@@ -6,15 +6,17 @@ export function createSourceMapFixture(
   entityId: string,
   overrides?: {
     origin?: string;
+    entityType?: 'Entry' | 'Asset';
     contentful?: Partial<Omit<ContentfulMetadata, 'entity'>>;
   },
 ): SourceMapMetadata {
   const origin = overrides?.origin ?? 'contentful.com';
-  const space = overrides?.contentful?.space ?? 'master';
-  const environment = overrides?.contentful?.environment ?? 'master';
-  const entityType = overrides?.contentful?.entityType ?? 'Entry';
-  const locale = overrides?.contentful?.locale ?? 'en-US';
-  const field = overrides?.contentful?.field ?? 'title';
+  const space = 'master';
+  const environment = 'master';
+  const entityType = overrides?.entityType ?? 'Entry';
+  const entityTypeUrl = entityType === 'Entry' ? 'entries' : 'assets';
+  const locale = 'en-US';
+  const field = 'title';
   const editorInterface = overrides?.contentful?.editorInterface ?? {
     widgetNamespace: 'builtin',
     widgetId: 'singleLine',
@@ -22,15 +24,9 @@ export function createSourceMapFixture(
   const fieldType = overrides?.contentful?.fieldType ?? 'Symbol';
 
   return {
-    href: `https://app.${origin}/spaces/${space}/environments/${environment}/entries/${entityId}?focusedField=${field}&focusedLocale=${locale}`,
+    href: `https://app.${origin}/spaces/${space}/environments/${environment}/${entityTypeUrl}/${entityId}?focusedField=${field}&focusedLocale=${locale}`,
     origin,
     contentful: {
-      space,
-      environment,
-      entity: entityId,
-      entityType,
-      field,
-      locale,
       editorInterface,
       fieldType,
     },

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.bench.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.bench.ts
@@ -61,7 +61,7 @@ describe('getAllTaggedElements', () => {
           <div id="img">
             <img
               src="./picture.jpg"
-              alt="${combine('Some alt text for the picture', createSourceMapFixture('img-1', { contentful: { entityType: 'Asset' } }))}"
+              alt="${combine('Some alt text for the picture', createSourceMapFixture('img-1', { entityType: 'Asset' }))}"
             />
           </div>
           <div id="picture">
@@ -69,7 +69,7 @@ describe('getAllTaggedElements', () => {
               <source srcset="/lion-potrait.jpg" media="(orientation: portrait)" />
               <img
                 src="/lion-298-332.jpg"
-                alt="${combine('A lion staring at the sun', createSourceMapFixture('img-2', { contentful: { entityType: 'Asset' } }))}"
+                alt="${combine('A lion staring at the sun', createSourceMapFixture('img-2', { entityType: 'Asset' }))}"
               />
             </picture>
           </div>
@@ -79,11 +79,11 @@ describe('getAllTaggedElements', () => {
                 <span>
                   <img
                     src="/elephant.jpg"
-                    alt="${combine('Elephant at sunset', createSourceMapFixture('img-3', { contentful: { entityType: 'Asset' } }))})}"
+                    alt="${combine('Elephant at sunset', createSourceMapFixture('img-3', { entityType: 'Asset' }))})}"
                   />
                 </span>
               </span>
-              <figcaption>${combine('An elephant at sunset', createSourceMapFixture('img-3', { contentful: { entityType: 'Asset' } }))})}</figcaption>
+              <figcaption>${combine('An elephant at sunset', createSourceMapFixture('img-3', { entityType: 'Asset' }))})}</figcaption>
             </figure>
           </div>
         </div>

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/getAllTaggedElements.test.ts
@@ -238,7 +238,7 @@ describe('getAllTaggedElements', () => {
       it('should tag elements with different information separately', () => {
         const referenceMetadata = createSourceMapFixture('reference');
         const globeMetadata = createSourceMapFixture('globe', {
-          contentful: { entityType: 'Asset' },
+          entityType: 'Asset',
         });
 
         const dom = html(`
@@ -306,9 +306,9 @@ describe('getAllTaggedElements', () => {
     });
 
     it('should tag the images correctly by prefering the wrapping picture or figure', () => {
-      const img1 = createSourceMapFixture('img1', { contentful: { entityType: 'Asset' } });
-      const img2 = createSourceMapFixture('img2', { contentful: { entityType: 'Asset' } });
-      const img3 = createSourceMapFixture('img3', { contentful: { entityType: 'Asset' } });
+      const img1 = createSourceMapFixture('img1', { entityType: 'Asset' });
+      const img2 = createSourceMapFixture('img2', { entityType: 'Asset' });
+      const img3 = createSourceMapFixture('img3', { entityType: 'Asset' });
 
       const dom = html(`
         <div>

--- a/packages/live-preview-sdk/src/inspectorMode/__tests__/parseAttributesFromHref.test.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/__tests__/parseAttributesFromHref.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseAttributesFromHref } from '../utils.js';
+
+describe('parseAttributesFromHref', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should extract all attributes from a valid Entry href', () => {
+    const href =
+      'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedField=title&focusedLocale=en-US&source=vercel-content-link';
+    const attributes = parseAttributesFromHref(href);
+    expect(attributes).toEqual({
+      entityId: 'a1b2c3',
+      entityType: 'Entry',
+      fieldId: 'title',
+      locale: 'en-US',
+      space: 'foo',
+      environment: 'master',
+    });
+  });
+
+  it('should extract all attributes from a valid Asset href', () => {
+    const href =
+      'https://app.contentful.com/spaces/foo/environments/master/assets/d4e5f6/?focusedField=file&focusedLocale=en-US&source=vercel-content-link';
+    const attributes = parseAttributesFromHref(href);
+    expect(attributes).toEqual({
+      entityId: 'd4e5f6',
+      entityType: 'Asset',
+      fieldId: 'file',
+      locale: 'en-US',
+      space: 'foo',
+      environment: 'master',
+    });
+  });
+
+  it('should return null and warn if focusedField is missing', () => {
+    const href =
+      'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/?focusedLocale=en-US&source=vercel-content-link';
+    const attributes = parseAttributesFromHref(href);
+    expect(attributes).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith('Missing focusedField query parameter in href', {
+      href,
+    });
+  });
+
+  it('should return null and warn if focusedLocale is missing', () => {
+    const href =
+      'https://app.contentful.com/spaces/foo/environments/master/assets/d4e5f6/?focusedField=file&source=vercel-content-link';
+    const attributes = parseAttributesFromHref(href);
+    expect(attributes).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith('Missing focusedLocale query parameter in href', {
+      href,
+    });
+  });
+
+  it('should return null and warn if query parameters are missing', () => {
+    const href = 'https://app.contentful.com/spaces/foo/environments/master/entries/a1b2c3/';
+    const attributes = parseAttributesFromHref(href);
+    expect(attributes).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith('Missing focusedField query parameter in href', {
+      href,
+    });
+  });
+
+  it('should return null and warn if spaces or environments are missing', () => {
+    const href = 'https://app.contentful.com/assets/d4e5f6/?focusedField=file&focusedLocale=en-US';
+    const attributes = parseAttributesFromHref(href);
+    expect(attributes).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith('Missing space or environment in href path', {
+      href,
+    });
+  });
+
+  it('should return null and warn if URL is malformed', () => {
+    const href = 'not a url';
+    const attributes = parseAttributesFromHref(href);
+    expect(attributes).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith('Invalid href URL', {
+      href,
+      error: expect.any(Error),
+    });
+  });
+
+  it('should return null and warn if href is empty', () => {
+    const href = '';
+    const attributes = parseAttributesFromHref(href);
+    expect(attributes).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith('Invalid href URL', {
+      href,
+      error: expect.any(Error),
+    });
+  });
+
+  it('should return null and warn if entity segment is missing', () => {
+    const href =
+      'https://app.contentful.com/spaces/foo/environments/master/?focusedField=title&focusedLocale=en-US';
+    const attributes = parseAttributesFromHref(href);
+    expect(attributes).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith(
+      'Unable to determine entityType or entityId from href',
+      { href },
+    );
+  });
+});

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -183,13 +183,13 @@ export function getAllTaggedElements({
         `[${InspectorModeDataAttributes.ASSET_ID}][${InspectorModeDataAttributes.FIELD_ID}], [${InspectorModeDataAttributes.ENTRY_ID}][${InspectorModeDataAttributes.FIELD_ID}]`,
       );
 
-  //Spread operator is necessary to convert the NodeList to an array
+  // Spread operator is necessary to convert the NodeList to an array
   const taggedElements: PrecaulculatedTaggedElement[] = [...alreadyTagged]
     .map((element: Element) => ({
       element,
       attributes: getManualInspectorModeAttributes(element, options),
     }))
-    //filter out elements that don't have the necessary attributes
+    // Filter out elements that don't have the necessary attributes
     .filter(({ attributes }) => attributes !== null);
   const elementsForTagging: AutoTaggedElement<Element>[] = [];
 
@@ -232,9 +232,84 @@ export function getAllTaggedElements({
   );
 
   for (const { element, sourceMap } of uniqElementsForTagging) {
-    if (!sourceMap.contentful) {
+    let inspectorModeAttributes: InspectorModeAttributes | null = null;
+
+    if (sourceMap.href) {
+      // Newer SDK versions will always have HREF, so we can use that to extract the attributes
+      const attributes = parseAttributesFromHref(sourceMap.href);
+
+      if (!attributes) {
+        // parseAttributesFromHref already logs a warning
+        continue;
+      }
+
+      if (attributes.entityType === 'Asset') {
+        inspectorModeAttributes = {
+          fieldId: attributes.fieldId,
+          locale: attributes.locale,
+          space: attributes.space,
+          environment: attributes.environment,
+          assetId: attributes.entityId,
+        } as InspectorModeAssetAttributes;
+      } else if (attributes.entityType === 'Entry') {
+        inspectorModeAttributes = {
+          fieldId: attributes.fieldId,
+          locale: attributes.locale,
+          space: attributes.space,
+          environment: attributes.environment,
+          entryId: attributes.entityId,
+        } as InspectorModeEntryAttributes;
+      } else {
+        // This should not happen, but adding a warning just in case
+        debug.warn('Unknown entityType', {
+          element,
+          sourceMap,
+        });
+        continue;
+      }
+    } else if (sourceMap.contentful) {
+      // Older SDK versions might not have HREF (if platform was set to 'contentful'), so we need to extract the attributes from sourceMap.contentful
+      const contentfulData = sourceMap.contentful;
+      if (
+        !contentfulData.entity ||
+        !contentfulData.field ||
+        !contentfulData.locale ||
+        !contentfulData.space ||
+        !contentfulData.environment
+      ) {
+        debug.warn(
+          'Element has missing information in their ContentSourceMap, please check if you have restricted the platform for the encoding. (Missing parameters in `contentful`)',
+          {
+            element,
+            sourceMap,
+          },
+        );
+        continue;
+      }
+
+      const attributes: InspectorModeSharedAttributes = {
+        fieldId: contentfulData.field,
+        locale: contentfulData.locale,
+        space: contentfulData.space,
+        environment: contentfulData.environment,
+      };
+
+      if (contentfulData.entityType === 'Asset') {
+        (attributes as InspectorModeAssetAttributes).assetId = contentfulData.entity;
+        inspectorModeAttributes = attributes as InspectorModeAssetAttributes;
+      } else if (contentfulData.entityType === 'Entry') {
+        (attributes as InspectorModeEntryAttributes).entryId = contentfulData.entity;
+        inspectorModeAttributes = attributes as InspectorModeEntryAttributes;
+      } else {
+        debug.warn('Unknown entityType in contentful data', {
+          element,
+          sourceMap,
+        });
+        continue;
+      }
+    } else {
       debug.warn(
-        'Element has missing information in their ContentSourceMap, please check if you have restricted the platform for the encoding. (Missing parameter: `contentful`)',
+        'Element has neither href nor contentful data in their ContentSourceMap, unable to extract attributes.',
         {
           element,
           sourceMap,
@@ -243,22 +318,9 @@ export function getAllTaggedElements({
       continue;
     }
 
-    const attributes: InspectorModeSharedAttributes = {
-      fieldId: sourceMap.contentful.field,
-      locale: sourceMap.contentful.locale,
-      space: sourceMap.contentful.space,
-      environment: sourceMap.contentful.environment,
-    };
-
-    if (sourceMap.contentful.entityType === 'Asset') {
-      (attributes as InspectorModeAssetAttributes).assetId = sourceMap.contentful.entity;
-    } else if (sourceMap.contentful.entityType === 'Entry') {
-      (attributes as InspectorModeEntryAttributes).entryId = sourceMap.contentful.entity;
-    }
-
     taggedElements.push({
       element,
-      attributes: attributes as InspectorModeAttributes,
+      attributes: inspectorModeAttributes,
     });
   }
 
@@ -345,3 +407,92 @@ export const addCalculatedAttributesToTaggedElements = (
   const taggedElementWithCoordinates = addCoordinatesToTaggedElements(taggedElements);
   return addVisibilityToTaggedElements(taggedElementWithCoordinates, root) as TaggedElement[];
 };
+
+/**
+ * Parses a Contentful `href` URL to extract shared attributes, including the entity ID and entity type.
+ *
+ * @param {string} href - The URL containing Contentful parameters.
+ * @returns {InspectorModeSharedAttributes | null} An object containing `entityId`, `entityType`, `fieldId`, `locale`, `space`, and `environment`, or `null` if parsing fails.
+ *
+ * The function extracts:
+ * - `entityId` and `entityType` from the path segments (`entries/` or `assets/`).
+ * - `fieldId` from the `focusedField` query parameter.
+ * - `locale` from the `focusedLocale` query parameter.
+ * - `space` from the path segment following `spaces/`.
+ * - `environment` from the path segment following `environments/`.
+ *
+ * If any of these elements are missing or the URL is malformed, the function logs a warning and returns `null`.
+ */
+export function parseAttributesFromHref(href: string): {
+  entityId: string;
+  entityType: 'Entry' | 'Asset';
+  fieldId: string;
+  locale: string;
+  space: string;
+  environment: string;
+} | null {
+  try {
+    const url = new URL(href);
+
+    // Extract query parameters
+    const fieldId = url.searchParams.get('focusedField');
+    const locale = url.searchParams.get('focusedLocale');
+
+    // Extract path segments
+    const pathSegments = url.pathname.split('/').filter(Boolean);
+
+    const spaceIndex = pathSegments.indexOf('spaces');
+    const environmentIndex = pathSegments.indexOf('environments');
+
+    const space = spaceIndex !== -1 ? pathSegments[spaceIndex + 1] : undefined;
+    const environment = environmentIndex !== -1 ? pathSegments[environmentIndex + 1] : undefined;
+
+    // Determine entityType and entityId
+    let entityType: 'Entry' | 'Asset' | undefined;
+    let entityId: string | undefined;
+
+    const entriesIndex = pathSegments.indexOf('entries');
+    const assetsIndex = pathSegments.indexOf('assets');
+
+    if (entriesIndex !== -1) {
+      entityType = 'Entry';
+      entityId = pathSegments[entriesIndex + 1];
+    } else if (assetsIndex !== -1) {
+      entityType = 'Asset';
+      entityId = pathSegments[assetsIndex + 1];
+    }
+
+    // Check for missing required attributes
+    if (!entityType || !entityId) {
+      console.warn('Unable to determine entityType or entityId from href', { href });
+      return null;
+    }
+
+    if (!fieldId) {
+      console.warn('Missing focusedField query parameter in href', { href });
+      return null;
+    }
+
+    if (!locale) {
+      console.warn('Missing focusedLocale query parameter in href', { href });
+      return null;
+    }
+
+    if (!space || !environment) {
+      console.warn('Missing space or environment in href path', { href });
+      return null;
+    }
+
+    return {
+      entityId,
+      entityType,
+      fieldId,
+      locale,
+      space,
+      environment,
+    };
+  } catch (error) {
+    console.warn('Invalid href URL', { href, error });
+    return null;
+  }
+}

--- a/packages/live-preview-sdk/src/inspectorMode/utils.ts
+++ b/packages/live-preview-sdk/src/inspectorMode/utils.ts
@@ -267,7 +267,7 @@ export function getAllTaggedElements({
         });
         continue;
       }
-    } else if (sourceMap.contentful) {
+    } else if (sourceMap.contentful && isLegacyContentfulData(sourceMap.contentful)) {
       // Older SDK versions might not have HREF (if platform was set to 'contentful'), so we need to extract the attributes from sourceMap.contentful
       const contentfulData = sourceMap.contentful;
       if (
@@ -495,4 +495,23 @@ export function parseAttributesFromHref(href: string): {
     console.warn('Invalid href URL', { href, error });
     return null;
   }
+}
+
+function isLegacyContentfulData(data: any): data is {
+  entity: string;
+  field: string;
+  locale: string;
+  space: string;
+  environment: string;
+  entityType: 'Asset' | 'Entry';
+} {
+  return (
+    data &&
+    typeof data.entity === 'string' &&
+    typeof data.field === 'string' &&
+    typeof data.locale === 'string' &&
+    typeof data.space === 'string' &&
+    typeof data.environment === 'string' &&
+    (data.entityType === 'Asset' || data.entityType === 'Entry')
+  );
 }


### PR DESCRIPTION
- Remove redundant info from hidden sourcemaps. We can determine the properties based on the Contentful HREF param and remove them from `contentful` object. This means that HREF param should now always be present, even if the platform is set to 'contentful'. Previously we only used the HREF param for Vercel Content Link. The code is still backwards compatible.
- Fix typescript issues: https://github.com/contentful/live-preview/issues/924