### PR TITLE
fix: undefined mappings in csm [TOL-2540]

### DIFF
--- a/packages/content-source-maps/src/richText.ts
+++ b/packages/content-source-maps/src/richText.ts
@@ -15,15 +15,27 @@ export const encodeRichTextValue = ({
   hiddenStrings: SourceMapMetadata;
 }) => {
   const source = mappings[pointer];
-  // remove old pointer to rich text field as we will just be mapping the text nodes
-  delete mappings[pointer];
 
-  const textNodes = findRichTextNodes(data, pointer);
-  for (const textNode of textNodes) {
-    mappings[textNode] = source;
-    const currentTextNodeValue = get(data, textNode);
-    const encodedValue = combine(currentTextNodeValue, hiddenStrings);
-    set(data, textNode, encodedValue);
+  // Only proceed with mapping if we have a valid source
+  if (source) {
+    // We can now safely delete the original pointer as we've preserved the source
+    delete mappings[pointer];
+
+    const textNodes = findRichTextNodes(data, pointer);
+    for (const textNode of textNodes) {
+      mappings[textNode] = source;
+      const currentTextNodeValue = get(data, textNode);
+      const encodedValue = combine(currentTextNodeValue, hiddenStrings);
+      set(data, textNode, encodedValue);
+    }
+  } else {
+    // If there's no source mapping, just encode the text nodes without creating mappings
+    const textNodes = findRichTextNodes(data, pointer);
+    for (const textNode of textNodes) {
+      const currentTextNodeValue = get(data, textNode);
+      const encodedValue = combine(currentTextNodeValue, hiddenStrings);
+      set(data, textNode, encodedValue);
+    }
   }
 };
 


### PR DESCRIPTION
## Problem
When encoding rich text fields, undefined values could be introduced into the `contentSourceMaps.mappings` object, causing serialisation errors in Next.js getStaticProps.

<img width="1496" alt="Screenshot 2024-12-10 at 14 59 35" src="https://github.com/user-attachments/assets/1c56a51b-2155-4d41-ac09-a4f1e3842dcb">
