### PR TITLE
fix: do not error when no source maps []

### DIFF
--- a/packages/content-source-maps/src/rest/encodeCPAResponse.ts
+++ b/packages/content-source-maps/src/rest/encodeCPAResponse.ts
@@ -28,8 +28,9 @@ const applyEncoding = (
 
   const { contentSourceMaps } = target.sys;
 
+  // Skip if there are no source maps
+  // For example if an entry has only one unsupported field
   if (!contentSourceMaps) {
-    console.error('Content source maps data is missing');
     return;
   }
 
@@ -130,7 +131,6 @@ export const encodeCPAResponse = (
   if (modifiedCPAResponse.sys && 'items' in (modifiedCPAResponse as CPAEntryCollection)) {
     const collection = modifiedCPAResponse as CPAEntryCollection;
     if (!collection.sys?.contentSourceMapsLookup) {
-      console.error('Content source maps lookup data is missing');
       return collection;
     }
     const {


### PR DESCRIPTION
Sometimes, entries will not respond with `contentSourceMaps` under `sys`, if they for example only have one field type that is not supported with content source maps. We should not throw an error in this case, but just return as normal

For example in this case we have an entry with only one field type (markdown) and no content source maps:
<img width="1398" alt="Screenshot 2025-02-14 at 13 29 25" src="https://github.com/user-attachments/assets/2b855f45-87fa-4e5e-b34f-ca51be7a7227" />
