### PR TITLE
chore: fix build warning [TOL-3207]

### DIFF
--- a/packages/live-preview-sdk/package.json
+++ b/packages/live-preview-sdk/package.json
@@ -15,14 +15,14 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     },
     "./react": {
+      "types": "./dist/react.d.ts",
       "import": "./dist/react.js",
-      "require": "./dist/react.cjs",
-      "types": "./dist/react.d.ts"
+      "require": "./dist/react.cjs"
     }
   },
   "repository": {


### PR DESCRIPTION
gets rid of this warning 

▲ [WARNING] The conditions "default" and "types" here will never be used as they come after both "import" and "require" [package.json]