### PR TITLE
feat(sdk): export internal types from public index for bundler resolution [SPA-4097]

### DIFF
--- a/packages/live-preview-sdk/src/__tests__/index.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/index.spec.ts
@@ -2,9 +2,16 @@
 import { Mock, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { isInsideIframe, sendMessageToEditor } from '../helpers/index.js';
-import { ContentfulLivePreview, LIVE_PREVIEW_EDITOR_SOURCE } from '../index.js';
+import {
+  ContentfulLivePreview,
+  LIVE_PREVIEW_EDITOR_SOURCE,
+  type Argument,
+  type SubscribeCallback,
+  InspectorModeDataAttributes,
+  type InspectorModeEntryTags,
+  type InspectorModeTags,
+} from '../index.js';
 import { InspectorMode } from '../inspectorMode/index.js';
-import { InspectorModeDataAttributes } from '../inspectorMode/types.js';
 import { LiveUpdates } from '../liveUpdates.js';
 import { SaveEvent } from '../saveEvent.js';
 
@@ -180,5 +187,39 @@ describe('ContentfulLivePreview', () => {
 
       expect(result).toBeNull();
     });
+  });
+});
+
+describe('public type exports', () => {
+  it('exports InspectorModeDataAttributes with correct values', () => {
+    expect(InspectorModeDataAttributes.FIELD_ID).toBe('data-contentful-field-id');
+    expect(InspectorModeDataAttributes.ENTRY_ID).toBe('data-contentful-entry-id');
+    expect(InspectorModeDataAttributes.ASSET_ID).toBe('data-contentful-asset-id');
+    expect(InspectorModeDataAttributes.LOCALE).toBe('data-contentful-locale');
+    expect(InspectorModeDataAttributes.SPACE).toBe('data-contentful-space');
+    expect(InspectorModeDataAttributes.ENVIRONMENT).toBe('data-contentful-environment');
+  });
+
+  it('Argument type is usable as a type annotation', () => {
+    const data: Argument = { id: '1' };
+    expect(data).toBeDefined();
+  });
+
+  it('SubscribeCallback type is usable as a type annotation', () => {
+    const cb: SubscribeCallback = (_data: Argument) => {};
+    expect(cb).toBeDefined();
+  });
+
+  it('InspectorModeEntryTags type is usable as a type annotation', () => {
+    const tags: InspectorModeEntryTags = {
+      [InspectorModeDataAttributes.FIELD_ID]: 'title',
+      [InspectorModeDataAttributes.ENTRY_ID]: 'entry-123',
+    };
+    expect(tags).toBeDefined();
+  });
+
+  it('InspectorModeTags type accepts null', () => {
+    const tags: InspectorModeTags = null;
+    expect(tags).toBeNull();
   });
 });

--- a/packages/live-preview-sdk/src/__tests__/index.spec.ts
+++ b/packages/live-preview-sdk/src/__tests__/index.spec.ts
@@ -2,16 +2,9 @@
 import { Mock, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { isInsideIframe, sendMessageToEditor } from '../helpers/index.js';
-import {
-  ContentfulLivePreview,
-  LIVE_PREVIEW_EDITOR_SOURCE,
-  type Argument,
-  type SubscribeCallback,
-  InspectorModeDataAttributes,
-  type InspectorModeEntryTags,
-  type InspectorModeTags,
-} from '../index.js';
+import { ContentfulLivePreview, LIVE_PREVIEW_EDITOR_SOURCE } from '../index.js';
 import { InspectorMode } from '../inspectorMode/index.js';
+import { InspectorModeDataAttributes } from '../inspectorMode/types.js';
 import { LiveUpdates } from '../liveUpdates.js';
 import { SaveEvent } from '../saveEvent.js';
 
@@ -187,39 +180,5 @@ describe('ContentfulLivePreview', () => {
 
       expect(result).toBeNull();
     });
-  });
-});
-
-describe('public type exports', () => {
-  it('exports InspectorModeDataAttributes with correct values', () => {
-    expect(InspectorModeDataAttributes.FIELD_ID).toBe('data-contentful-field-id');
-    expect(InspectorModeDataAttributes.ENTRY_ID).toBe('data-contentful-entry-id');
-    expect(InspectorModeDataAttributes.ASSET_ID).toBe('data-contentful-asset-id');
-    expect(InspectorModeDataAttributes.LOCALE).toBe('data-contentful-locale');
-    expect(InspectorModeDataAttributes.SPACE).toBe('data-contentful-space');
-    expect(InspectorModeDataAttributes.ENVIRONMENT).toBe('data-contentful-environment');
-  });
-
-  it('Argument type is usable as a type annotation', () => {
-    const data: Argument = { id: '1' };
-    expect(data).toBeDefined();
-  });
-
-  it('SubscribeCallback type is usable as a type annotation', () => {
-    const cb: SubscribeCallback = (_data: Argument) => {};
-    expect(cb).toBeDefined();
-  });
-
-  it('InspectorModeEntryTags type is usable as a type annotation', () => {
-    const tags: InspectorModeEntryTags = {
-      [InspectorModeDataAttributes.FIELD_ID]: 'title',
-      [InspectorModeDataAttributes.ENTRY_ID]: 'entry-123',
-    };
-    expect(tags).toBeDefined();
-  });
-
-  it('InspectorModeTags type accepts null', () => {
-    const tags: InspectorModeTags = null;
-    expect(tags).toBeNull();
   });
 });

--- a/packages/live-preview-sdk/src/index.ts
+++ b/packages/live-preview-sdk/src/index.ts
@@ -409,3 +409,10 @@ export { LIVE_PREVIEW_EDITOR_SOURCE, LIVE_PREVIEW_SDK_SOURCE } from './constants
 
 export * from './messages.js';
 export { encodeGraphQLResponse, encodeCPAResponse, splitEncoding, parseAttributesFromHref };
+
+export type { Argument, SubscribeCallback } from './types.js';
+export {
+  InspectorModeDataAttributes,
+  type InspectorModeEntryTags,
+  type InspectorModeTags,
+} from './inspectorMode/types.js';


### PR DESCRIPTION
## Summary

- Re-exports `Argument`, `SubscribeCallback`, `InspectorModeDataAttributes`, `InspectorModeEntryTags`, and `InspectorModeTags` from the public `@contentful/live-preview` entry point
- Fixes `TS2307: Cannot find module` errors for consumers using `moduleResolution: "bundler"` (Angular v20/v21 default), who previously had to import from internal `dist/` paths not listed in the `exports` map
- Purely additive — no existing consumers are affected

## Context

The [composable-storefront-integration-library](https://github.com/contentful/composable-storefront-integration-library) imports these types from `@contentful/live-preview/dist/types` and `@contentful/live-preview/dist/inspectorMode/types`. Under `moduleResolution: "node"` TypeScript bypasses the `exports` map and resolves those paths directly. Under `moduleResolution: "bundler"` (Angular v21 default) TypeScript enforces the `exports` map strictly — those unlisted paths are rejected with `TS2307`. This PR makes the fix on the SDK side. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR re-exports internal types from the public index to resolve TypeScript module resolution errors for consumers using 'bundler' mode, ensuring compatibility with Angular v20/v21 defaults without impacting existing users. The changes add exports for Argument, SubscribeCallback, InspectorModeDataAttributes, InspectorModeEntryTags, and InspectorModeTags, and include corresponding test adjustments in index.spec.ts.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds export statements for Argument, SubscribeCallback, InspectorModeDataAttributes, InspectorModeEntryTags, and InspectorModeTags in index.ts from their respective internal modules to make them publicly accessible.</li>

<li>Removes imports of the exported types from the public index and the associated test cases in index.spec.ts, instead importing InspectorModeDataAttributes directly from its internal module.</li>

</ul>
</details>

</div>