### PR TITLE
docs: add AI harness readiness documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+This file gives coding agents the repository-specific context needed to make safe, reviewable changes.
+
+## Repository overview
+
+- This is a TypeScript monorepo for Contentful's live-preview libraries.
+- Yarn workspaces and Lerna coordinate the packages under `packages/`.
+- The public packages are `@contentful/live-preview`, `@contentful/content-source-maps`, and `@contentful/timeline-preview`.
+- `packages/live-preview-sdk` owns inspector mode, editor messaging, live updates, and the React integration.
+- `packages/content-source-maps` encodes Contentful REST and GraphQL responses with source-map metadata.
+- `packages/timeline-preview` creates and parses timeline-preview tokens.
+- `examples/` contains integration examples and is not part of the root workspace package list.
+
+For a fuller map of the system, read [ARCHITECTURE.md](./ARCHITECTURE.md).
+
+## Working in the repository
+
+- Use the Node.js version in `.nvmrc` and Yarn Classic; install dependencies with `yarn install`.
+- Run commands from the repository root unless a package-local command is specifically required.
+- Build all packages with `yarn build`.
+- Run static checks with `yarn lint` and `yarn tsc`.
+- Run the non-interactive test suite with `yarn test:ci`; `yarn test` starts package test runners in their normal interactive mode.
+- Use `yarn lerna run <script> --scope <package-name>` when a focused package command is sufficient.
+- Do not hand-edit generated `dist/` output or package changelogs as part of a normal source change.
+
+## Change guidelines
+
+- Keep public APIs compatible unless the task explicitly calls for a breaking change.
+- Preserve both ESM and CommonJS exports and generated TypeScript declarations when changing package entry points.
+- Treat values received through `window.postMessage` as untrusted and retain origin and message validation.
+- Keep browser-only access guarded so server-side imports of the SDK remain safe.
+- Add or update colocated Vitest tests for behavior changes; tests use the `jsdom` environment.
+- Update relevant package or root documentation when behavior visible to consumers changes.
+- Follow the existing ESLint and Prettier configuration and use conventional commit messages.
+
+## Review checklist
+
+- Confirm the smallest relevant tests pass, then run `yarn lint`, `yarn tsc`, and `yarn build` when practical.
+- Check package export maps and bundle externals if imports, entry points, or dependencies changed.
+- Check that no credentials, Contentful access tokens, or customer content were added to fixtures or examples.
+- Keep changes scoped; avoid unrelated formatting or dependency-lock updates.
+- Follow `.github/CODEOWNERS`: Experience Assembly owns the repository generally, while Content Authoring and Publishing owns `packages/timeline-preview`.
+
+## Architectural decisions
+
+Decision records live in `docs/adr/`. Add a record when a change establishes a long-lived constraint, changes package boundaries or public entry points, or adopts repository-wide infrastructure.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,47 @@
+# Architecture
+
+## Purpose
+
+This repository contains the libraries used by a preview website to communicate with Contentful, update preview content, expose inspector-mode metadata, and support timeline previews. The code is shipped as independently versioned npm packages from one TypeScript monorepo.
+
+## System context
+
+A customer application imports one or more packages from this repository. When the application is rendered inside Contentful's preview iframe, `@contentful/live-preview` exchanges validated `window.postMessage` events with the Contentful editor. The SDK can annotate or discover DOM elements for inspector mode and merge incoming content changes into the original REST or GraphQL response shape. The companion libraries provide response encoding and timeline-token utilities without owning the editor connection.
+
+## Repository structure
+
+- `packages/live-preview-sdk/` builds `@contentful/live-preview`, the main browser SDK and its React entry point.
+- `packages/content-source-maps/` builds `@contentful/content-source-maps`, which encodes and decodes metadata used to associate rendered values with Contentful entities and fields.
+- `packages/timeline-preview/` builds `@contentful/timeline-preview`, a small package for timeline-preview token creation and parsing.
+- `examples/` demonstrates framework integrations including Next.js, Gatsby, Remix, Apollo, GraphQL, the Content Preview API, and vanilla JavaScript.
+- `.circleci/config.yml` defines validation, release, and canary-release pipelines.
+- `.github/` holds ownership, pull-request labeling, and workflow security configuration.
+
+## Package relationships
+
+`@contentful/live-preview` depends on `@contentful/content-source-maps` for encoding helpers used by its public live-update APIs. The timeline package is independent of the other workspace packages. React and React DOM are peer dependencies of the live-preview SDK and are externalized from its bundles.
+
+Each package exposes source from `src/`, colocates tests under `src/` or `src/__tests__/`, and writes generated artifacts to `dist/`. Package export maps expose ESM and CommonJS builds plus TypeScript declarations. Vite and `vite-plugin-dts` produce these artifacts, while Vitest runs tests in `jsdom`.
+
+## Main live-preview components
+
+- `ContentfulLivePreview` is the main static API. It initializes the SDK, controls feature flags and locale, and coordinates browser integrations.
+- `InspectorMode` manages tagged elements and editor interactions for selecting entries, assets, and fields.
+- `LiveUpdates` receives editor updates and applies them to subscribed Contentful response data.
+- `SaveEvent` coordinates save-related messaging.
+- `messages.ts` and `helpers/validateMessage.ts` define and validate the cross-window protocol.
+- `react.tsx` supplies the provider and hooks through the `@contentful/live-preview/react` entry point.
+
+## Runtime boundaries and data flow
+
+The live-preview package may be imported during server rendering, but interactive behavior starts only when a browser `window` exists and the page is inside an iframe. Initialization validates configuration, determines allowed Contentful origins, enables requested modules, registers the message listener, and announces the SDK to the editor. Incoming messages are validated before being forwarded to inspector, update, or save components. Subscribers then receive updated data, and React hooks publish it through component state.
+
+Content-source-map functions operate on original Contentful REST or GraphQL response structures. Consumers should apply application-specific transformations after live updates because transformations can remove the identity and shape information needed to merge changes correctly.
+
+## Build, validation, and release
+
+Yarn workspaces install shared dependencies and Lerna runs package scripts. TypeScript uses strict checks with `NodeNext` module resolution. The normal validation path is linting, type checking, building, and Vitest execution. CircleCI runs those checks before publishing independently versioned packages from `main`; the `canary` branch produces prereleases. Lerna derives versions and release notes from conventional commits.
+
+## Ownership and decisions
+
+The Experience Assembly team owns the repository by default. Content Authoring and Publishing owns the timeline-preview package. Significant, durable architectural decisions are recorded under `docs/adr/`; see [ADR-0001](./docs/adr/0001-independent-packages-in-a-monorepo.md) for the current package and build model.

--- a/docs/adr/0001-independent-packages-in-a-monorepo.md
+++ b/docs/adr/0001-independent-packages-in-a-monorepo.md
@@ -1,0 +1,42 @@
+# ADR-0001: Maintain independently versioned packages in one monorepo
+
+- Status: Accepted
+- Date: 2026-08-26
+
+## Context
+
+Live preview is delivered through several related libraries. The main SDK uses content-source-map functionality, while timeline preview provides a smaller independent capability. These packages share TypeScript, linting, test, and release conventions, and changes can span package boundaries. Consumers still need to install and update each public library independently.
+
+The repository already uses Yarn workspaces, Lerna, Vite, and per-package export maps. This record documents that established design so future changes preserve its intended boundaries.
+
+## Decision
+
+We will keep the public libraries in a single Yarn and Lerna monorepo under `packages/`, with independent package versions.
+
+Each package will:
+
+- own its source, tests, manifest, build configuration, changelog, and public export map;
+- publish ESM and CommonJS artifacts plus TypeScript declarations from `dist/`;
+- expose only deliberate package entry points rather than internal source paths; and
+- be releasable independently through Lerna's conventional-commit workflow.
+
+Shared root configuration will define TypeScript, linting, formatting, dependency installation, and CI conventions. Cross-package functionality must be consumed through another package's public API and declared in the consumer's manifest. The React integration remains a secondary `@contentful/live-preview/react` export, with React and React DOM kept as peer dependencies and external bundle dependencies.
+
+## Consequences
+
+- Related changes can be reviewed and validated atomically in one repository.
+- Tooling and CI behavior remain consistent across packages.
+- Consumers can adopt content-source-map, live-preview, and timeline capabilities on separate release schedules.
+- Contributors must consider dependency ranges and release impact when changing a shared package.
+- Package boundaries, export maps, and CommonJS/ESM compatibility require explicit validation.
+- Root-wide commands may do more work than a package-focused change needs, so Lerna scopes are appropriate for fast local feedback.
+
+## Alternatives considered
+
+### One combined package
+
+This would simplify version coordination but would couple unrelated timeline and encoding use cases to the full browser SDK and its dependency surface.
+
+### A repository for every package
+
+This would isolate releases, but it would duplicate tooling and make coordinated SDK and content-source-map changes slower and harder to validate together.


### PR DESCRIPTION
## Summary

- add repository-specific guidance for coding agents
- document the package architecture, runtime boundaries, build, validation, release, and ownership model
- record the existing independently versioned monorepo decision in an ADR

## Why

[SPA-5167](https://contentful.atlassian.net/browse/SPA-5167) introduces governance controls requiring substantive `AGENTS.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md`, and an architectural decision record. This repository already had a substantive `CONTRIBUTING.md`; the other three artifacts were missing.

## Impact

This is documentation-only. It makes the repository easier for contributors and coding agents to navigate and satisfies the AI harness readiness controls without changing runtime or package behavior.

## Validation

- `yarn prettier --check AGENTS.md ARCHITECTURE.md docs/adr/0001-independent-packages-in-a-monorepo.md`
- `git diff --check`
- confirmed each governance document exceeds 10 non-blank lines

[SPA-5167]: https://contentful.atlassian.net/browse/SPA-5167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ